### PR TITLE
docs: compact author list and fix Paul's link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://people.eecs.berkeley.edu/~jegonzal/">Joseph E. Gonzalez</a>†,
   <a href="https://www.sewonmin.com/">Sewon Min</a>†
 </p>
-<p align="center"><sub>* Equal contribution &nbsp; † Equal advising</sub></p>
+<p align="center"><sub>* Equal contribution &nbsp; † Equal advising</sub><br><sub>Work done at <a href="https://sky.cs.berkeley.edu/">Berkeley SkyLab</a> &amp; <a href="https://bair.berkeley.edu/">BAIR</a> &amp; <a href="https://nlp.cs.berkeley.edu/">Berkeley NLP</a></sub></p>
 <p align="center">Search any document by how it <em>looks</em>, not just the text it contains.</p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -4,16 +4,7 @@
 <p align="center">
   Official codebase for <b><a href="assets/pixelrag-paper.pdf">PixelRAG: Visually Grounded Retrieval-Augmented Generation with Screenshot Rendering</a></b>
 </p>
-<p align="center">
-  <a href="https://yichuan-w.github.io/">Yichuan Wang</a>*,
-  <a href="https://zhifei.li/">Zhifei Li</a>*,
-  <a href="https://zwcolin.github.io/">Zirui Wang</a>,
-  <a href="https://people.epfl.ch/paul.teiletche">Paul Teiletche</a>,
-  <a href="https://www.linkedin.com/in/lesheng-jin-9618b0201/">Lesheng Jin</a>,
-  <a href="https://people.eecs.berkeley.edu/~matei/">Matei Zaharia</a>†,
-  <a href="https://people.eecs.berkeley.edu/~jegonzal/">Joseph E. Gonzalez</a>†,
-  <a href="https://www.sewonmin.com/">Sewon Min</a>†
-</p>
+<p align="center"><a href="https://yichuan-w.github.io/">Yichuan Wang</a>*, <a href="https://zhifei.li/">Zhifei Li</a>*, <a href="https://zwcolin.github.io/">Zirui Wang</a>, <a href="https://www.linkedin.com/in/paul-teiletche/">Paul Teiletche</a>, <a href="https://www.linkedin.com/in/lesheng-jin-9618b0201/">Lesheng Jin</a>, <a href="https://people.eecs.berkeley.edu/~matei/">Matei Zaharia</a>†, <a href="https://people.eecs.berkeley.edu/~jegonzal/">Joseph E. Gonzalez</a>†, <a href="https://www.sewonmin.com/">Sewon Min</a>†</p>
 <p align="center"><sub>* Equal contribution &nbsp; † Equal advising</sub></p>
 <p align="center">Search any document by how it <em>looks</em>, not just the text it contains.</p>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 <p align="center">
   Official codebase for <b><a href="assets/pixelrag-paper.pdf">PixelRAG: Visually Grounded Retrieval-Augmented Generation with Screenshot Rendering</a></b>
 </p>
-<p align="center"><sub><a href="https://yichuan-w.github.io/">Yichuan Wang</a>*, <a href="https://zhifei.li/">Zhifei Li</a>*, <a href="https://zwcolin.github.io/">Zirui Wang</a>, <a href="https://www.linkedin.com/in/paul-teiletche/">Paul Teiletche</a>, <a href="https://www.linkedin.com/in/lesheng-jin-9618b0201/">Lesheng Jin</a>, <a href="https://people.eecs.berkeley.edu/~matei/">Matei Zaharia</a>†, <a href="https://people.eecs.berkeley.edu/~jegonzal/">Joseph E. Gonzalez</a>†, <a href="https://www.sewonmin.com/">Sewon Min</a>†</sub></p>
+<p align="center">
+  <a href="https://yichuan-w.github.io/">Yichuan Wang</a>*,
+  <a href="https://zhifei.li/">Zhifei Li</a>*,
+  <a href="https://zwcolin.github.io/">Zirui Wang</a>,
+  <a href="https://www.linkedin.com/in/paul-teiletche/">Paul Teiletche</a>,
+  <a href="https://www.linkedin.com/in/lesheng-jin-9618b0201/">Lesheng Jin</a>
+  <br>
+  <a href="https://people.eecs.berkeley.edu/~matei/">Matei Zaharia</a>†,
+  <a href="https://people.eecs.berkeley.edu/~jegonzal/">Joseph E. Gonzalez</a>†,
+  <a href="https://www.sewonmin.com/">Sewon Min</a>†
+</p>
 <p align="center"><sub>* Equal contribution &nbsp; † Equal advising</sub></p>
 <p align="center">Search any document by how it <em>looks</em>, not just the text it contains.</p>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <p align="center">
   Official codebase for <b><a href="assets/pixelrag-paper.pdf">PixelRAG: Visually Grounded Retrieval-Augmented Generation with Screenshot Rendering</a></b>
 </p>
-<p align="center"><a href="https://yichuan-w.github.io/">Yichuan Wang</a>*, <a href="https://zhifei.li/">Zhifei Li</a>*, <a href="https://zwcolin.github.io/">Zirui Wang</a>, <a href="https://www.linkedin.com/in/paul-teiletche/">Paul Teiletche</a>, <a href="https://www.linkedin.com/in/lesheng-jin-9618b0201/">Lesheng Jin</a>, <a href="https://people.eecs.berkeley.edu/~matei/">Matei Zaharia</a>†, <a href="https://people.eecs.berkeley.edu/~jegonzal/">Joseph E. Gonzalez</a>†, <a href="https://www.sewonmin.com/">Sewon Min</a>†</p>
+<p align="center"><sub><a href="https://yichuan-w.github.io/">Yichuan Wang</a>*, <a href="https://zhifei.li/">Zhifei Li</a>*, <a href="https://zwcolin.github.io/">Zirui Wang</a>, <a href="https://www.linkedin.com/in/paul-teiletche/">Paul Teiletche</a>, <a href="https://www.linkedin.com/in/lesheng-jin-9618b0201/">Lesheng Jin</a>, <a href="https://people.eecs.berkeley.edu/~matei/">Matei Zaharia</a>†, <a href="https://people.eecs.berkeley.edu/~jegonzal/">Joseph E. Gonzalez</a>†, <a href="https://www.sewonmin.com/">Sewon Min</a>†</sub></p>
 <p align="center"><sub>* Equal contribution &nbsp; † Equal advising</sub></p>
 <p align="center">Search any document by how it <em>looks</em>, not just the text it contains.</p>
 


### PR DESCRIPTION
## Summary
- Put all authors on a single HTML line so Sewon Min no longer wraps to a second row
- Update Paul Teiletche's link from EPFL profile to his LinkedIn (https://www.linkedin.com/in/paul-teiletche/)

## Test plan
- [ ] Check README renders correctly on GitHub — all 8 authors on one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)