### PR TITLE
fix(web): update tile count to 28.1M and use production URL in API docs

### DIFF
--- a/web/app/chat/page.tsx
+++ b/web/app/chat/page.tsx
@@ -327,7 +327,7 @@ function EmptyState({ onExample, onSearchMode }: { onExample: (q: string) => voi
         </motion.h1>
 
         <motion.p initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.3 }} className="mx-auto mt-5 max-w-md text-[14px] leading-relaxed text-[var(--chat-secondary)]">
-          Ask a question. I&apos;ll search 15.7M Wikipedia screenshot tiles,
+          Ask a question. I&apos;ll search 28.1M Wikipedia screenshot tiles,
           read the visual results, and synthesize an answer.
         </motion.p>
       </div>

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -61,7 +61,7 @@ const endpoints: Endpoint[] = [
         ]},
       ]},
     ],
-    curlPrefix: `curl -X POST http://localhost:3000/api/search \\
+    curlPrefix: `curl -X POST https://pixelrag.ai/api/search \\
   -H "Content-Type: application/json"`,
     defaultBody: JSON.stringify({ queries: [{ text: "solar system" }], n_docs: 5 }, null, 2),
   },
@@ -84,7 +84,7 @@ const endpoints: Endpoint[] = [
       { name: "index_size_bytes", type: "number", required: true, description: "FAISS index file size" },
       { name: "metadata_size_bytes", type: "number", required: true, description: "Metadata NPZ size" },
     ],
-    curlPrefix: `curl http://localhost:3000/api/status`,
+    curlPrefix: `curl https://pixelrag.ai/api/status`,
   },
   {
     id: "tile",
@@ -101,7 +101,7 @@ const endpoints: Endpoint[] = [
     responseFields: [
       { name: "(binary)", type: "image/png", required: true, description: "PNG image data" },
     ],
-    curlPrefix: `curl http://localhost:3000/api/tile`,
+    curlPrefix: `curl https://pixelrag.ai/api/tile`,
     defaultParams: "article_id=2840114&tile_index=0&chunk_index=0",
     buildPath: (_body, params) => {
       const p = new URLSearchParams(params)
@@ -118,7 +118,7 @@ const endpoints: Endpoint[] = [
     responseFields: [
       { name: "status", type: "string", required: true, description: "Always \"ok\"" },
     ],
-    curlPrefix: `curl http://localhost:3000/api/health`,
+    curlPrefix: `curl https://pixelrag.ai/api/health`,
   },
 ]
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -157,7 +157,7 @@ function SearchPageContent() {
                 <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-60" />
                 <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-primary" />
               </span>
-              15.7M screenshot tiles · indexed
+              28.1M screenshot tiles · indexed
             </div>
             <h1
               className="reveal relative font-display text-5xl font-light leading-[1.05] tracking-tight sm:text-7xl"


### PR DESCRIPTION
## Summary
- Update screenshot tile count from 15.7M to 28.1M in chat page and landing page

## Test plan
- [ ] Check chat page placeholder text shows 28.1M
- [ ] Check landing page stats badge shows 28.1M

🤖 Generated with [Claude Code](https://claude.com/claude-code)