### PR TITLE
style(web): enlarge nav cat logo (h-7 → h-9)

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({
                 <img
                   src="/logo.png"
                   alt=""
-                  className="h-7 w-auto transition-transform duration-300 group-hover:scale-105 dark:invert"
+                  className="h-9 w-auto transition-transform duration-300 group-hover:scale-105 dark:invert"
                 />
                 <span className="flex items-baseline gap-0.5">
                   <span className="font-display text-xl font-semibold tracking-tight">


### PR DESCRIPTION
Bumps the top-left nav logo from 28px to 36px so the PixelRAG cat reads more clearly next to the wordmark. Verified via screenshot. (The .ipynb demo and other recent work already landed on main.)