### PR TITLE
feat(web): page titles + vivid 'reading screenshots' status

### DIFF
--- a/web/app/chat/layout.tsx
+++ b/web/app/chat/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Ask",
+  description:
+    "Ask anything about Wikipedia — PixelRAG searches screenshot tiles, reads them, and answers with citations.",
+}
+
+export default function ChatLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/web/app/chat/page.tsx
+++ b/web/app/chat/page.tsx
@@ -518,12 +518,30 @@ function ThinkingTrace({ text, active }: { text: string; active: boolean }) {
 
 /* ─── Tile Gallery ─── */
 
+// Vivid, varied phrasing for "Claude is reading the screenshots with its eyes".
+const READING_VERBS = [
+  "Looking at",
+  "Reading",
+  "Studying",
+  "Examining",
+  "Poring over",
+  "Peering at",
+  "Taking in",
+  "Scanning",
+]
+
 function TileGallery({ tiles, loading }: { tiles: TileView[]; loading?: boolean }) {
+  const n = tiles.length
+  // Seed by the first tile so the verb stays put as more tiles stream in,
+  // but differs from answer to answer.
+  const verb = READING_VERBS[(tiles[0]?.article_id ?? n) % READING_VERBS.length]
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mb-5">
       <div className="mb-2.5 flex items-center gap-2">
         <Eye className="h-3.5 w-3.5 text-[var(--chat-warm)]" />
-        <span className="text-[12px] font-medium text-[var(--chat-secondary)]">Reading {tiles.length} tile{tiles.length > 1 ? "s" : ""}</span>
+        <span className="text-[12px] font-medium text-[var(--chat-secondary)]">
+          {verb} {n} screenshot{n > 1 ? "s" : ""}
+        </span>
         {loading && <Loader2 className="h-3 w-3 animate-spin text-[var(--chat-warm)]" />}
       </div>
       <div className="flex gap-2.5 overflow-x-auto pb-1 scrollbar-thin">

--- a/web/app/docs/layout.tsx
+++ b/web/app/docs/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "API Reference",
+  description:
+    "PixelRAG HTTP API — search a hosted index of 8.28M Wikipedia screenshot tiles by text or image, and fetch the matching screenshots.",
+}
+
+export default function DocsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import { Inter, Crimson_Pro, JetBrains_Mono } from "next/font/google"
 
 import "./globals.css"
@@ -11,6 +12,16 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   variable: "--font-mono",
 })
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://pixelrag.ai"),
+  title: {
+    default: "PixelRAG — visual Wikipedia search",
+    template: "%s · PixelRAG",
+  },
+  description:
+    "Search Wikipedia by how it looks, not just the text it contains. PixelRAG renders pages as screenshots and retrieves over the images.",
+}
 
 export default function RootLayout({
   children,


### PR DESCRIPTION
- **Titles** — there was no `metadata` anywhere, so every tab showed the Next.js default (no title). Added a root title template (`%s · PixelRAG`) + per-route titles. /chat now reads **Ask · PixelRAG**, /docs **API Reference · PixelRAG**, home **PixelRAG — visual Wikipedia search**. Verified in the rendered HTML.
- **Tile status** — the chat gallery's static "Reading N tiles" becomes a varied, human verb (Looking at / Studying / Poring over / Peering at / … N screenshots), evoking Claude actually reading with its eyes. Seeded by the first tile so it's stable as tiles stream in but differs per answer.