### PR TITLE
feat(web): show the user's recent questions in the ask UI

### DIFF
--- a/web/app/chat/page.tsx
+++ b/web/app/chat/page.tsx
@@ -14,8 +14,10 @@ import {
   ChevronRight,
   ImagePlus,
   X,
+  Clock,
 } from "lucide-react"
 import { tileUrl } from "@/lib/api"
+import { getHistory, addHistory, clearHistory } from "@/lib/history"
 import { motion, AnimatePresence } from "framer-motion"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
@@ -113,6 +115,7 @@ function ChatPageInner() {
     const query = (text ?? input).trim()
     const img = imageOverride ?? image
     if ((!query && !img) || isStreaming) return
+    if (query) addHistory(query, "ask")
     const userMsg: ChatMessage = { id: crypto.randomUUID(), role: "user", content: query, image: img }
     const assistantMsg: ChatMessage = { id: crypto.randomUUID(), role: "assistant", content: "", searches: [] }
     setMessages((prev) => [...prev, userMsg, assistantMsg])
@@ -300,6 +303,8 @@ export default function ChatPage() {
 /* ─── Empty State ─── */
 
 function EmptyState({ onExample, onSearchMode }: { onExample: (q: string) => void; onSearchMode: () => void }) {
+  const [recent, setRecent] = React.useState<string[]>([])
+  React.useEffect(() => setRecent(getHistory("ask")), [])
   return (
     <div className="relative flex h-full flex-col items-center justify-center px-6">
       {/* Background mesh */}
@@ -353,6 +358,35 @@ function EmptyState({ onExample, onSearchMode }: { onExample: (q: string) => voi
           </button>
         ))}
       </motion.div>
+
+      {/* Your recent questions (saved locally on this device) */}
+      {recent.length > 0 && (
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.5 }} className="relative z-10 mt-7 w-full max-w-lg">
+          <div className="mb-2.5 flex items-center justify-between px-1">
+            <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--chat-muted)]">
+              <Clock className="h-3 w-3" /> Recent
+            </span>
+            <button
+              onClick={() => { clearHistory("ask"); setRecent([]) }}
+              className="text-[11px] text-[var(--chat-muted)] transition-colors hover:text-[var(--chat-secondary)]"
+            >
+              Clear
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {recent.map((q) => (
+              <button
+                key={q}
+                onClick={() => onExample(q)}
+                title={q}
+                className="max-w-[15rem] truncate rounded-full border border-[var(--chat-border)] bg-[var(--chat-card)] px-3 py-1.5 text-[12px] text-[var(--chat-secondary)] transition-all hover:border-[var(--chat-accent-dim)] hover:text-[var(--chat-fg)]"
+              >
+                {q}
+              </button>
+            ))}
+          </div>
+        </motion.div>
+      )}
     </div>
   )
 }

--- a/web/lib/history.ts
+++ b/web/lib/history.ts
@@ -1,10 +1,14 @@
-const KEY = "pixelrag-search-history"
-const MAX = 10
+// Per-user, client-side query history kept in localStorage. Two independent
+// namespaces: "search" (the visual search box) and "ask" (the agent chat).
+type Kind = "search" | "ask"
 
-export function getHistory(): string[] {
+const MAX = 10
+const keyFor = (kind: Kind) => `pixelrag-${kind}-history`
+
+export function getHistory(kind: Kind = "search"): string[] {
   if (typeof window === "undefined") return []
   try {
-    const raw = localStorage.getItem(KEY)
+    const raw = localStorage.getItem(keyFor(kind))
     if (!raw) return []
     const parsed = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
@@ -14,24 +18,24 @@ export function getHistory(): string[] {
   }
 }
 
-export function addHistory(query: string): void {
+export function addHistory(query: string, kind: Kind = "search"): void {
   if (typeof window === "undefined") return
   const trimmed = query.trim()
   if (!trimmed) return
   try {
-    const prev = getHistory()
+    const prev = getHistory(kind)
     const deduped = prev.filter((s) => s !== trimmed)
     const next = [trimmed, ...deduped].slice(0, MAX)
-    localStorage.setItem(KEY, JSON.stringify(next))
+    localStorage.setItem(keyFor(kind), JSON.stringify(next))
   } catch {
     // localStorage unavailable — silently ignore
   }
 }
 
-export function clearHistory(): void {
+export function clearHistory(kind: Kind = "search"): void {
   if (typeof window === "undefined") return
   try {
-    localStorage.removeItem(KEY)
+    localStorage.removeItem(keyFor(kind))
   } catch {
     // silently ignore
   }


### PR DESCRIPTION
"Agent history" for the **end user** (not an operator view): a returning visitor can see and revisit their own past questions.

- Generalizes `lib/history` with an `ask` namespace; the `search` namespace keeps its existing localStorage key, so existing search history is untouched.
- Saves each asked question; shows a **Recent** row on the chat empty state (click a chip to re-ask, **Clear** to wipe).
- Per-device, client-side only — no backend, no server-side storage of user queries.

Build passes; mirrors the existing search-history dropdown pattern.