### PR TITLE
feat(web): highlight docs example + enlarge nav wordmark

### DIFF
--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -251,6 +251,42 @@ function Code({ children }: { children: React.ReactNode }) {
   )
 }
 
+// Minimal, dependency-free shell highlighter for the curl examples — colors
+// comments, commands, flags, quoted strings, and URLs.
+function ShellBlock({ code }: { code: string }) {
+  const TOKEN =
+    /(#.*)|("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|(https?:\/\/[^\s'"]+)|(\bcurl\b)|(\s-{1,2}[A-Za-z][\w-]*)/g
+  const nodes: React.ReactNode[] = []
+  let last = 0
+  let m: RegExpExecArray | null
+  let key = 0
+  while ((m = TOKEN.exec(code)) !== null) {
+    if (m.index > last) nodes.push(code.slice(last, m.index))
+    const [full, comment, str, url, cmd] = m
+    const cls = comment
+      ? "italic text-muted-foreground/60"
+      : str
+        ? "text-green-600 dark:text-green-400"
+        : url
+          ? "text-blue-600 dark:text-blue-400"
+          : cmd
+            ? "font-medium text-purple-600 dark:text-purple-400"
+            : "text-amber-600 dark:text-amber-400" // flag
+    nodes.push(
+      <span key={key++} className={cls}>
+        {full}
+      </span>
+    )
+    last = m.index + full.length
+  }
+  if (last < code.length) nodes.push(code.slice(last))
+  return (
+    <pre className="mt-3 overflow-x-auto rounded-xl border border-border/60 bg-card p-4 text-xs leading-relaxed text-foreground/80">
+      <code>{nodes}</code>
+    </pre>
+  )
+}
+
 function FlowStep({
   n,
   method,
@@ -326,8 +362,8 @@ function OverviewSection({ onSelect }: { onSelect: (id: string) => void }) {
       <p className="mt-2 text-sm text-muted-foreground">
         Search, then fetch the top hit&apos;s screenshot:
       </p>
-      <pre className="mt-3 overflow-x-auto rounded-xl border border-border/60 bg-card p-4 text-xs leading-relaxed">
-        <code>{`# 1 — search (text or image query)
+      <ShellBlock
+        code={`# 1 — search (text or image query)
 curl -X POST https://pixelrag.ai/api/search \\
   -H "Content-Type: application/json" \\
   -d '{"queries": [{"text": "How does photosynthesis work?"}], "n_docs": 5}'
@@ -335,8 +371,8 @@ curl -X POST https://pixelrag.ai/api/search \\
 # → hits[0] = { "article_id": 2840114, "tile_index": 0, "chunk_index": 0, ... }
 
 # 2 — fetch that hit's screenshot
-curl https://pixelrag.ai/api/tile/2840114/0/0 --output tile.png`}</code>
-      </pre>
+curl https://pixelrag.ai/api/tile/2840114/0/0 --output tile.png`}
+      />
 
       <h2 className="mt-10 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
         Base URL

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -45,7 +45,7 @@ export default function RootLayout({
           <nav className="sticky top-0 z-50 bg-background/70 backdrop-blur-xl">
             <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6">
               {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-              <a href="/" className="group flex items-center gap-2.5">
+              <a href="/" className="group flex items-center gap-3.5">
                 {/* Logo mark — PixelRAG cat (inverts to white in dark mode) */}
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
@@ -54,10 +54,10 @@ export default function RootLayout({
                   className="h-9 w-auto transition-transform duration-300 group-hover:scale-105 dark:invert"
                 />
                 <span className="flex items-baseline gap-0.5">
-                  <span className="font-display text-xl font-semibold tracking-tight">
+                  <span className="font-display text-2xl font-semibold tracking-tight">
                     Pixel
                   </span>
-                  <span className="font-display text-xl font-semibold tracking-tight text-primary">
+                  <span className="font-display text-2xl font-semibold tracking-tight text-primary">
                     RAG
                   </span>
                 </span>


### PR DESCRIPTION
- API docs Overview: the curl example is now syntax-highlighted (small dependency-free highlighter — comments, commands, flags, strings, URLs).
- Nav: PixelRAG wordmark enlarged (text-xl → text-2xl) and the gap to the logo widened.

(README product screenshot still pending — capturing separately.)