### PR TITLE
fix(agent): identify-then-name image strategy (+ honest 'can't ID')

### DIFF
--- a/web/agent-server.mjs
+++ b/web/agent-server.mjs
@@ -55,7 +55,7 @@ const SYSTEM_PROMPT = `You are PixelRAG's research assistant. You answer using a
 
 For every user question, without exception:
 1. Call pixelrag_search to find relevant Wikipedia articles.
-   - If the user uploaded an image, set use_uploaded_image: true to include it in the search (visual similarity) — the best way to answer "what/who is this?" or "which X does this most resemble?". You can add a text query in the SAME call to combine image + text into one joint search, and you may also run separate text searches for likely candidates to compare against. Always do the image search first when an image is present.
+   - If the user uploaded an image, set use_uploaded_image: true to include it in the search. CRITICAL: the index is whole Wikipedia *page* screenshots, so a cropped face or object rarely matches on its own, and a GENERIC description ("a young man with glasses") makes results worse. Instead, first try to IDENTIFY the subject from your own knowledge and put your best guess of its real NAME in the text query alongside the image (a person's name, a landmark's name, etc.) — image + the correct name retrieves far better than either alone. If unsure, try a few candidate names across separate searches. Only fall back to image-only (no text) when you genuinely cannot guess a name. Always include the image in the search when one is present.
    - Otherwise pass a natural-language query.
 2. Call pixelrag_tile to VIEW the screenshot tiles of the top results — this is how you read and compare. View at least 2-3 tiles.
 3. Answer from what the tiles show, and cite the Wikipedia URLs. If the tiles don't contain the answer, say so honestly.

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -22,7 +22,7 @@ const SYSTEM_PROMPT = `You are PixelRAG's research assistant. You answer using a
 
 For every user question, without exception:
 1. Call pixelrag_search to find relevant Wikipedia articles.
-   - If the user uploaded an image, set use_uploaded_image: true to include it in the search (visual similarity) — the best way to answer "what/who is this?" or "which X does this most resemble?". You can add a text query in the SAME call to combine image + text into one joint search, and you may also run separate text searches for likely candidates to compare against. Always do the image search first when an image is present.
+   - If the user uploaded an image, set use_uploaded_image: true to include it in the search. CRITICAL: the index is whole Wikipedia *page* screenshots, so a cropped face or object rarely matches on its own, and a GENERIC description ("a young man with glasses") makes results worse. Instead, first try to IDENTIFY the subject from your own knowledge and put your best guess of its real NAME in the text query alongside the image (a person's name, a landmark's name, etc.) — image + the correct name retrieves far better than either alone. If unsure, try a few candidate names across separate searches. Only fall back to image-only (no text) when you genuinely cannot guess a name. Always include the image in the search when one is present.
    - Otherwise pass a natural-language query.
 2. Call pixelrag_tile to VIEW the screenshot tiles of the top results — this is how you read and compare. View at least 2-3 tiles.
 3. Answer from what the tiles show, and cite the Wikipedia URLs. If the tiles don't contain the answer, say so honestly.


### PR DESCRIPTION
Follow-up to the image-search fix after the Matei test case.

**Diagnosis** (from the live transcript + index probes): the agent *was* using the image, but paired it with a generic description, and a face photo can't match whole-page screenshots. Index probes with his actual uploaded photo:
- text `Matei Zaharia` alone → his page not in top 5
- image alone → random people (~0.34)
- **image + `Matei Zaharia` → his page #2** ✅

So the only path is image + the correct name. This steers the agent to identify-then-name instead of describing generically. It does **not** fix faces the model can't recognize (e.g. Matei) — there the agent now honestly says it can't identify rather than hallucinating.

Deployed to the live agent for testing.