### PR TITLE
fix(deploy): pixelrag-api unit used the removed pixelrag-serve binary

### DIFF
--- a/deploy/pixelrag-api.service
+++ b/deploy/pixelrag-api.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=yichuan
 WorkingDirectory=/home/yichuan/visrag
-ExecStart=/home/yichuan/visrag/.venv/bin/pixelrag-serve \
+ExecStart=/home/yichuan/visrag/.venv/bin/pixelrag serve \
     --index-dir /home/yichuan/visrag-data/search_index \
     --tiles-dir /home/yichuan/visrag-data/tiles \
     --articles-json /home/yichuan/visrag-data/articles.json \


### PR DESCRIPTION
After collapsing to a single `pixelrag` package, the `pixelrag-serve` console script no longer exists (only `pixelrag` and `pixelshot`). The `pixelrag-api.service` unit still launched `.venv/bin/pixelrag-serve`, so the live search API was running off a deleted file and **would fail on the next restart/reboot**. Switched to `pixelrag serve` (same module via the umbrella CLI).

This also explains the "`pixelrag-serve --help` printed nothing" confusion — that binary is gone; the command is now `pixelrag serve --help`.

The live host unit is already patched + `daemon-reload`ed (running service untouched, no downtime); this PR syncs the repo copy.