### PR TITLE
ci: self-hosted CD (egress-only runner, deploy box stays private)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy
+
+# Continuous deployment to the self-hosted box. Triggers ONLY on push to main
+# (post-merge = trusted code) and manual dispatch — never on pull_request — so
+# fork PRs can't run on the self-hosted runner. The frontend deploys separately
+# via Vercel; this handles the agent backend / Python services on the box.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, deploy]
+    steps:
+      - name: Fast-forward working tree + restart what changed
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          cd /home/yichuan/visrag
+
+          # Safety: this box is also a dev machine. Only deploy when it's on a
+          # clean main — never clobber in-progress branch work.
+          branch=$(git rev-parse --abbrev-ref HEAD)
+          if [ "$branch" != "main" ]; then
+            echo "::warning::deploy box is on '$branch', not main — skipping (deploy manually when back on main)"
+            exit 0
+          fi
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            echo "::warning::deploy box has uncommitted changes — skipping to avoid clobbering"
+            exit 0
+          fi
+
+          git fetch origin main
+          git merge --ff-only origin/main
+          bash deploy/deploy.sh "${BEFORE:-}"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# PixelRAG self-hosted CD.
+#
+# Runs on the deploy box via the GitHub Actions self-hosted runner after a push
+# to main (see .github/workflows/deploy.yml). The working tree has already been
+# fast-forwarded to origin/main by the workflow; this script decides what to
+# (re)start based on what actually changed, so a docs-only push costs nothing
+# and the expensive 216G search index is never reloaded automatically.
+#
+# Usage: deploy/deploy.sh [BEFORE_SHA]
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+export PATH="$HOME/.local/bin:$HOME/.nix-profile/bin:$PATH"
+
+BEFORE="${1:-}"
+mkdir -p logs
+LOG=logs/cd.log
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+say() { echo "$(ts) $*" | tee -a "$LOG"; }
+
+AFTER=$(git rev-parse HEAD)
+say "deploy: ${BEFORE:-<none>} -> ${AFTER}"
+
+if [ -n "$BEFORE" ] && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+  CHANGED=$(git diff --name-only "$BEFORE" "$AFTER")
+else
+  # First run / unknown base: treat the tip commit's files as the change set.
+  CHANGED=$(git show --name-only --pretty="" "$AFTER")
+fi
+say "changed: $(echo "$CHANGED" | tr '\n' ' ')"
+
+changed() { echo "$CHANGED" | grep -qE "$1"; }
+
+# 1. Python deps
+if changed '^uv\.lock$'; then
+  say "uv.lock changed -> uv sync"
+  uv sync >>"$LOG" 2>&1 || say "WARN: uv sync failed"
+fi
+
+# 2. Agent backend — cheap restart, safe to automate.
+if changed '^web/agent-server\.mjs$'; then
+  say "agent-server.mjs changed -> restart pixelrag-agent"
+  sudo systemctl restart pixelrag-agent.service
+  sleep 2
+  say "pixelrag-agent: $(systemctl is-active pixelrag-agent.service)"
+fi
+
+# 3. Search API — restarting reloads a 216G index (minutes of downtime), so we
+#    NEVER auto-restart it. Just flag that a manual restart is needed.
+if changed '^serve/'; then
+  say "NOTICE: serve/ changed — 'sudo systemctl restart pixelrag-api' needed manually (216G reload)"
+fi
+
+# The web frontend deploys via Vercel; nothing to do here for web/ changes
+# other than the agent backend handled above.
+say "deploy done"


### PR DESCRIPTION
Sets up continuous deployment to the deploy box via a **self-hosted GitHub Actions runner** — the industry 'bridge' for deploying behind a firewall ([GitHub Blog](https://github.blog/enterprise-software/ci-cd/when-to-choose-github-hosted-runners-or-self-hosted-runners-with-github-actions/)).

**Why a runner, not SSH-from-Actions:** the runner dials **outbound** to GitHub (egress-only), so there's no inbound access, **no SSH keys or hostnames in the repo/secrets**, and the machine stays private (GitHub only sees the generic name `pixelrag-deploy`). Works through the firewall/jump with zero network config.

**Public-repo safety:** the workflow triggers **only on `push` to main** (post-merge = trusted) and `workflow_dispatch` — never `pull_request` — so fork PRs can't run on the runner. All PR/CI workflows stay on GitHub-hosted runners.

**What it does:** `deploy/deploy.sh` restarts only what changed — `uv sync` on `uv.lock`, restart the agent on `agent-server.mjs`, and only *flags* `serve/` changes (the 216G index reload is never automated). It also refuses to deploy unless the box is on a clean `main`, so it can't clobber in-progress dev work (the box doubles as the dev machine). The web frontend continues to deploy via Vercel.