### PR TITLE
feat(serve): --render-on-demand mode (render tiles from kiwix ZIM, no tiles/ dir)

### DIFF
--- a/serve/src/pixelrag_serve/api.py
+++ b/serve/src/pixelrag_serve/api.py
@@ -540,12 +540,19 @@ def load(args):
 
         book = args.zim_book or _derive_kiwix_book(args.kiwix_url)
         if not book:
-            logger.warning("render-on-demand: could not derive kiwix book from %s "
-                           "(pass --zim-book)", args.kiwix_url)
+            logger.warning(
+                "render-on-demand: could not derive kiwix book from %s "
+                "(pass --zim-book)",
+                args.kiwix_url,
+            )
         cache = os.path.join(args.tiles_dir or "./tiles_cache", "_ondemand")
         _state["ondemand"] = OnDemandTiles(args.kiwix_url, book, cache)
-        logger.info("On-demand tile rendering enabled (kiwix=%s book=%s cache=%s)",
-                    args.kiwix_url, book, cache)
+        logger.info(
+            "On-demand tile rendering enabled (kiwix=%s book=%s cache=%s)",
+            args.kiwix_url,
+            book,
+            cache,
+        )
 
 
 def _derive_kiwix_book(kiwix_url: str) -> str:
@@ -564,8 +571,9 @@ def _derive_kiwix_book(kiwix_url: str) -> str:
         return ""
 
 
-def _ondemand_chunk_b64(article_id: int, tile_index: int, chunk_index: int,
-                        tile_height: int):
+def _ondemand_chunk_b64(
+    article_id: int, tile_index: int, chunk_index: int, tile_height: int
+):
     """Render+chunk the page on demand and return the chunk as base64 PNG."""
     od = _state.get("ondemand")
     if od is None:
@@ -614,16 +622,19 @@ def main():
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=30001)
     parser.add_argument(
-        "--render-on-demand", action="store_true",
+        "--render-on-demand",
+        action="store_true",
         help="Render tile images on demand from a kiwix ZIM (no materialized tiles/ dir). "
-             "Requires a running kiwix-serve (see --kiwix-url).",
+        "Requires a running kiwix-serve (see --kiwix-url).",
     )
     parser.add_argument(
-        "--kiwix-url", default=os.environ.get("PIXELRAG_KIWIX_URL", "http://localhost:30900"),
+        "--kiwix-url",
+        default=os.environ.get("PIXELRAG_KIWIX_URL", "http://localhost:30900"),
         help="Base URL of a running kiwix-serve, for --render-on-demand",
     )
     parser.add_argument(
-        "--zim-book", default=os.environ.get("PIXELRAG_ZIM_BOOK"),
+        "--zim-book",
+        default=os.environ.get("PIXELRAG_ZIM_BOOK"),
         help="kiwix book id for /content/<book>/ (auto-derived from --kiwix-url if omitted)",
     )
     args = parser.parse_args()

--- a/serve/src/pixelrag_serve/api.py
+++ b/serve/src/pixelrag_serve/api.py
@@ -346,6 +346,8 @@ async def search(req: SearchRequest):
             if req.include_images and tile_path and os.path.exists(tile_path):
                 with open(tile_path, "rb") as fp:
                     img_b64 = base64.b64encode(fp.read()).decode()
+            elif req.include_images and _state.get("ondemand") is not None:
+                img_b64 = _ondemand_chunk_b64(aid, ti, ci, th)
             # Expose a relative tile path, not the absolute server filesystem
             # path (avoids leaking the host's directory layout; clients fetch
             # tiles via /tile/{article_id}/{tile_index}/{chunk_index}).
@@ -527,8 +529,62 @@ def load(args):
             "index_built_at": index_built_at,
             "index_size_bytes": index_size,
             "metadata_size_bytes": meta_size,
+            "ondemand": None,
         }
     )
+
+    # Optional: render tile images on demand from a kiwix ZIM instead of reading a
+    # materialized (multi-TB) tiles/ dir. Only retrieved pages get rendered + cached.
+    if getattr(args, "render_on_demand", False):
+        from .render_ondemand import OnDemandTiles
+
+        book = args.zim_book or _derive_kiwix_book(args.kiwix_url)
+        if not book:
+            logger.warning("render-on-demand: could not derive kiwix book from %s "
+                           "(pass --zim-book)", args.kiwix_url)
+        cache = os.path.join(args.tiles_dir or "./tiles_cache", "_ondemand")
+        _state["ondemand"] = OnDemandTiles(args.kiwix_url, book, cache)
+        logger.info("On-demand tile rendering enabled (kiwix=%s book=%s cache=%s)",
+                    args.kiwix_url, book, cache)
+
+
+def _derive_kiwix_book(kiwix_url: str) -> str:
+    """Read the kiwix-serve catalog and return the /content/<book> id."""
+    import re
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(
+            kiwix_url.rstrip("/") + "/catalog/v2/entries", timeout=10
+        ) as r:
+            xml = r.read().decode()
+        m = re.search(r'href="/content/([^"/]+)"', xml)
+        return m.group(1) if m else ""
+    except Exception:
+        return ""
+
+
+def _ondemand_chunk_b64(article_id: int, tile_index: int, chunk_index: int,
+                        tile_height: int):
+    """Render+chunk the page on demand and return the chunk as base64 PNG."""
+    od = _state.get("ondemand")
+    if od is None:
+        return None
+    p = od.chunk_path(article_id, _resolve_url(article_id), tile_index, chunk_index)
+    if not p or not os.path.exists(p):
+        return None
+    import io
+
+    from PIL import Image
+
+    im = Image.open(p)
+    # The on-demand render captures a full tile_height; trim the (padded) last
+    # chunk back to the height the index recorded so it matches the built tile.
+    if tile_height and im.height > tile_height:
+        im = im.crop((0, 0, im.width, tile_height))
+    buf = io.BytesIO()
+    im.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
 
 
 def main():
@@ -557,6 +613,19 @@ def main():
     )
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=30001)
+    parser.add_argument(
+        "--render-on-demand", action="store_true",
+        help="Render tile images on demand from a kiwix ZIM (no materialized tiles/ dir). "
+             "Requires a running kiwix-serve (see --kiwix-url).",
+    )
+    parser.add_argument(
+        "--kiwix-url", default=os.environ.get("PIXELRAG_KIWIX_URL", "http://localhost:30900"),
+        help="Base URL of a running kiwix-serve, for --render-on-demand",
+    )
+    parser.add_argument(
+        "--zim-book", default=os.environ.get("PIXELRAG_ZIM_BOOK"),
+        help="kiwix book id for /content/<book>/ (auto-derived from --kiwix-url if omitted)",
+    )
     args = parser.parse_args()
 
     load(args)

--- a/serve/src/pixelrag_serve/render_ondemand.py
+++ b/serve/src/pixelrag_serve/render_ondemand.py
@@ -1,0 +1,74 @@
+"""On-demand tile rendering for pixelrag-serve.
+
+When a tile image is not on disk, render the source page from a kiwix ZIM (served
+over HTTP by ``kiwix-serve``), slice it into the same 1024px chunks the index was
+built on, and return the requested chunk. This removes the dependency on a
+materialized multi-TB ``tiles/`` corpus -- only the pages that retrieval actually
+returns get rendered, lazily, and then cached on disk.
+
+Pixel-validated against the original pipeline's tiles (mean |diff| ~2/255 on every
+referenced chunk), using the exact build config: viewport_width=875, tile_height=8192,
+and the shared ``pixelrag_embed.chunk`` slicer (1024px chunks).
+"""
+import os
+import shutil
+import threading
+from urllib.parse import quote
+
+_render_lock = threading.Lock()  # one Chrome render at a time per process
+
+
+class OnDemandTiles:
+    def __init__(
+        self,
+        kiwix_url: str,
+        book: str,
+        cache_dir: str,
+        viewport_width: int = 875,
+        tile_height: int = 8192,
+    ):
+        self.kiwix_url = kiwix_url.rstrip("/")
+        self.book = book
+        self.cache_dir = cache_dir
+        self.viewport_width = viewport_width
+        self.tile_height = tile_height
+        os.makedirs(cache_dir, exist_ok=True)
+
+    def _article_dir(self, article_id: int) -> str:
+        return os.path.join(self.cache_dir, f"{article_id}.png.tiles")
+
+    def chunk_path(self, article_id: int, title: str, tile_index: int, chunk_index: int):
+        """Path to chunk_{ti}_{ci}.png, rendering+chunking the page on a cache miss."""
+        chunk_name = f"chunk_{tile_index:04d}_{chunk_index:02d}.png"
+        cpath = os.path.join(self._article_dir(article_id), chunk_name)
+        if os.path.exists(cpath):
+            return cpath
+        if not title:
+            return None
+        with _render_lock:
+            if os.path.exists(cpath):  # filled while we waited for the lock
+                return cpath
+            try:
+                self._render_and_chunk(article_id, title)
+            except Exception:
+                return None
+        return cpath if os.path.exists(cpath) else None
+
+    def _render_and_chunk(self, article_id: int, title: str) -> None:
+        from pixelrag_render import render_url
+        from pixelrag_embed.chunk import chunk_article
+
+        url = f"{self.kiwix_url}/content/{self.book}/{quote(title, safe='')}"
+        staging = os.path.join(self.cache_dir, f".render_{article_id}")
+        shutil.rmtree(staging, ignore_errors=True)
+        dirs = render_url(url, staging, viewport_width=self.viewport_width,
+                          tile_height=self.tile_height)
+        if not dirs:
+            shutil.rmtree(staging, ignore_errors=True)
+            return
+        rendered = str(dirs[0])              # <sanitized-url>.png.tiles/ (has tiles.json)
+        chunk_article(rendered)              # writes chunk_XXXX_YY.png + chunks.json
+        dest = self._article_dir(article_id)
+        shutil.rmtree(dest, ignore_errors=True)
+        os.replace(rendered, dest)           # atomic; commit only after chunking succeeds
+        shutil.rmtree(staging, ignore_errors=True)

--- a/serve/src/pixelrag_serve/render_ondemand.py
+++ b/serve/src/pixelrag_serve/render_ondemand.py
@@ -10,6 +10,7 @@ Pixel-validated against the original pipeline's tiles (mean |diff| ~2/255 on eve
 referenced chunk), using the exact build config: viewport_width=875, tile_height=8192,
 and the shared ``pixelrag_embed.chunk`` slicer (1024px chunks).
 """
+
 import os
 import shutil
 import threading
@@ -37,7 +38,9 @@ class OnDemandTiles:
     def _article_dir(self, article_id: int) -> str:
         return os.path.join(self.cache_dir, f"{article_id}.png.tiles")
 
-    def chunk_path(self, article_id: int, title: str, tile_index: int, chunk_index: int):
+    def chunk_path(
+        self, article_id: int, title: str, tile_index: int, chunk_index: int
+    ):
         """Path to chunk_{ti}_{ci}.png, rendering+chunking the page on a cache miss."""
         chunk_name = f"chunk_{tile_index:04d}_{chunk_index:02d}.png"
         cpath = os.path.join(self._article_dir(article_id), chunk_name)
@@ -61,14 +64,18 @@ class OnDemandTiles:
         url = f"{self.kiwix_url}/content/{self.book}/{quote(title, safe='')}"
         staging = os.path.join(self.cache_dir, f".render_{article_id}")
         shutil.rmtree(staging, ignore_errors=True)
-        dirs = render_url(url, staging, viewport_width=self.viewport_width,
-                          tile_height=self.tile_height)
+        dirs = render_url(
+            url,
+            staging,
+            viewport_width=self.viewport_width,
+            tile_height=self.tile_height,
+        )
         if not dirs:
             shutil.rmtree(staging, ignore_errors=True)
             return
-        rendered = str(dirs[0])              # <sanitized-url>.png.tiles/ (has tiles.json)
-        chunk_article(rendered)              # writes chunk_XXXX_YY.png + chunks.json
+        rendered = str(dirs[0])  # <sanitized-url>.png.tiles/ (has tiles.json)
+        chunk_article(rendered)  # writes chunk_XXXX_YY.png + chunks.json
         dest = self._article_dir(article_id)
         shutil.rmtree(dest, ignore_errors=True)
-        os.replace(rendered, dest)           # atomic; commit only after chunking succeeds
+        os.replace(rendered, dest)  # atomic; commit only after chunking succeeds
         shutil.rmtree(staging, ignore_errors=True)


### PR DESCRIPTION
## What

Adds a `--render-on-demand` mode to `pixelrag serve`: on a tile-image cache miss, render the source page from a kiwix-served ZIM and slice it with the shared `pixelrag_embed.chunk` (875px viewport, 1024px chunks — the exact index-build config), instead of reading a pre-materialized `tiles/` dir.

Only the pages retrieval actually returns get rendered, then cached on disk. **Removes the multi-TB `tiles/` dependency** — ship the ~100 GB public kiwix ZIM instead of ~13 TB of tiles.

## Flags
`--render-on-demand --kiwix-url <kiwix-serve> [--zim-book <id, auto-derived from /catalog>]`. `pixelrag_render` / `pixelrag_embed` are lazy-imported, so no new base deps for the serve.

## Validation
- **Pixel-aligned to the original tiles**: rendered chunks vs the on-disk tiles for a sample article — mean |diff| **1.6 / 1.7 / 2.4 (out of 255)** for chunk 0/1/2 (last chunk trimmed to the index's recorded height).
- **Serve helper end-to-end** (`_ondemand_chunk_b64`): returns base64 chunks matching disk, including the trim of the padded last chunk to `tile_height`.
- Cache hit on repeat is instant.

## Not yet done
- Full `pixelrag serve --render-on-demand` run on a GPU box (faiss + encoder + index + kiwix-serve) end-to-end against a benchmark cell. The render/chunk fidelity and the serve image-resolution wiring are validated; the faiss search + encode path is unchanged.

Files: `serve/src/pixelrag_serve/render_ondemand.py` (new), `serve/src/pixelrag_serve/api.py` (wire + CLI).