### PR TITLE
fix(cd): uv sync must include serve extra (torch/faiss)

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -32,10 +32,13 @@ say "changed: $(echo "$CHANGED" | tr '\n' ' ')"
 
 changed() { echo "$CHANGED" | grep -qE "$1"; }
 
-# 1. Python deps
+# 1. Python deps. MUST include the extras the box runs (the search API needs the
+# `serve` extra: torch, transformers, faiss-cpu). A bare `uv sync` installs only
+# the light core and would UNINSTALL torch/faiss, breaking the serves on their
+# next restart. `all` = embed+serve+index (no gpu — there's no CUDA here).
 if changed '^uv\.lock$'; then
-  say "uv.lock changed -> uv sync"
-  uv sync >>"$LOG" 2>&1 || say "WARN: uv sync failed"
+  say "uv.lock changed -> uv sync --extra all"
+  uv sync --extra all >>"$LOG" 2>&1 || say "WARN: uv sync failed"
 fi
 
 # 2. Agent backend — cheap restart, safe to automate.


### PR DESCRIPTION
The CD's bare `uv sync` installs only the light core and **uninstalls** torch/transformers/faiss-cpu (they're in the `serve`/`embed` extras). On the last `uv.lock` change the CD stripped them; the running serves survived on in-memory copies but **crashed on restart** with `No module named 'torch'`. Fixed to `uv sync --extra all` (embed+serve+index; no gpu extra since there's no CUDA here).

Caught while doing the blue-green rollout of the `articles_only` filter — green crashed on restart, production stayed safe on blue.