### PR TITLE
fix(web): restore concrete-subject search examples (bring back The Starry Night)

### DIFF
--- a/web/components/SearchBar.tsx
+++ b/web/components/SearchBar.tsx
@@ -6,14 +6,16 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { getHistory, clearHistory } from "@/lib/history"
 
-// Both modes take natural language — the embedding model is trained on it, and
-// it retrieves better than bare keywords.
+// Search mode shows a visual grid, so concrete subjects beat full questions:
+// "The Starry Night" surfaces a striking spread of different artists' starry-night
+// paintings, where a verbose question just repeats the same one. Ask mode (below)
+// stays conversational.
 const EXAMPLE_QUERIES = [
-  "What does Van Gogh's The Starry Night look like?",
-  "How is the periodic table laid out?",
-  "What does the Taj Mahal look like?",
-  "What is depicted in The Great Wave off Kanagawa?",
-  "兵马俑长什么样？",
+  "The Starry Night",
+  "Periodic table",
+  "Taj Mahal",
+  "The Great Wave off Kanagawa",
+  "兵马俑",
 ]
 
 const ASK_EXAMPLES = [

--- a/web/components/SearchBar.tsx
+++ b/web/components/SearchBar.tsx
@@ -6,10 +6,11 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { getHistory, clearHistory } from "@/lib/history"
 
-// Search mode shows a visual grid, so concrete subjects beat full questions:
-// "The Starry Night" surfaces a striking spread of different artists' starry-night
-// paintings, where a verbose question just repeats the same one. Ask mode (below)
-// stays conversational.
+// The embedding model is trained on natural-language questions (SimpleQA-style),
+// which retrieve the target page most precisely — Ask mode leans on that. The
+// search grid deliberately uses bare, slightly ambiguous titles instead: "The
+// Starry Night" fans out to Van Gogh + Munch + Millet + the Dutch Sterrennacht,
+// a far more striking visual spread than one painting repeated five times.
 const EXAMPLE_QUERIES = [
   "The Starry Night",
   "Periodic table",


### PR DESCRIPTION
Search mode renders a visual grid. A bare subject like **The Starry Night** surfaces a striking spread of *different* starry-night paintings (Van Gogh, Munch, Millet, the Dutch Sterrennacht); the natural-language rewrite just repeated the same painting. Reverted search examples to concrete subjects; ask mode stays conversational.

Backed by a retrieval comparison (see below) — for named entities, bare keywords tie or beat full questions on the top hit and give more diverse results.