### PR TITLE
fix(web): search grid should not filter meta pages (they're the best-looking tiles)

### DIFF
--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -15,9 +15,11 @@ export async function search(req: SearchRequest): Promise<SearchResponse> {
   return fetchApi<SearchResponse>("/search", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    // Default to article pages (drop Portal:/List_of_/disambiguation meta pages);
-    // an explicit articles_only in req still wins.
-    body: JSON.stringify({ articles_only: true, ...req }),
+    // NOTE: the visual grid intentionally does NOT set articles_only — the
+    // Portal/Featured-picture pages it would drop are often the most visually
+    // striking tiles (panoramas, paintings), which is the point of this view.
+    // The chat agent DOES filter (it reads article text to answer questions).
+    body: JSON.stringify(req),
   });
 }
 


### PR DESCRIPTION
Compared the **actual tiles** (not just URLs) for 'Taj Mahal' with and without `articles_only`:
- **No filter**: five full-bleed Taj Mahal photo tiles (Portal panoramas / featured pictures) — gorgeous.
- **Filtered**: mostly text-wall article chunks.

The visual grid is the showcase, so it goes back to unfiltered. The **agent keeps** `articles_only=true` (it reads article text to answer — Portal pages are noise there). Split-by-consumer, not global.