### PR TITLE
fix(web): clean up API docs — parameterized /tile path, truthful examples, image-query one-liner

### DIFF
--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -67,6 +67,28 @@ const endpoints: Endpoint[] = [
     defaultBody: JSON.stringify({ queries: [{ text: "solar system" }], n_docs: 5 }, null, 2),
   },
   {
+    id: "tile",
+    method: "GET",
+    path: "/tile/{article_id}/{tile_index}/{chunk_index}",
+    summary: "Retrieve a tile image",
+    description:
+      "Fetches the screenshot image for a /search hit — pass the article_id, tile_index, and chunk_index straight from a search result. Returns PNG binary data; embed it with an <img> tag. The example below is the top of the Albert Einstein article.",
+    requestFields: [
+      { name: "article_id", type: "number", required: true, description: "Wikipedia article ID" },
+      { name: "tile_index", type: "number", required: true, description: "Which 8192px tile (0-based)" },
+      { name: "chunk_index", type: "number", required: true, description: "Which 1024px chunk within tile (0-based)" },
+    ],
+    responseFields: [
+      { name: "(binary)", type: "image/png", required: true, description: "PNG image data" },
+    ],
+    curlPrefix: `curl https://pixelrag.ai/api/tile`,
+    defaultParams: "article_id=698618&tile_index=0&chunk_index=0",
+    buildPath: (_body, params) => {
+      const p = new URLSearchParams(params)
+      return `/tile/${p.get("article_id") || "698618"}/${p.get("tile_index") || "0"}/${p.get("chunk_index") || "0"}`
+    },
+  },
+  {
     id: "status",
     method: "GET",
     path: "/status",
@@ -86,28 +108,6 @@ const endpoints: Endpoint[] = [
       { name: "metadata_size_bytes", type: "number", required: true, description: "Metadata NPZ size" },
     ],
     curlPrefix: `curl https://pixelrag.ai/api/status`,
-  },
-  {
-    id: "tile",
-    method: "GET",
-    path: "/tile/2840114/0/0",
-    summary: "Retrieve a tile image",
-    description:
-      "Fetches the screenshot image for a /search hit — pass the article_id, tile_index, and chunk_index straight from a search result. Returns PNG binary data; embed it with an <img> tag. The example below is the top of the Albert Einstein article.",
-    requestFields: [
-      { name: "article_id", type: "number", required: true, description: "Wikipedia article ID" },
-      { name: "tile_index", type: "number", required: true, description: "Which 8192px tile (0-based)" },
-      { name: "chunk_index", type: "number", required: true, description: "Which 1024px chunk within tile (0-based)" },
-    ],
-    responseFields: [
-      { name: "(binary)", type: "image/png", required: true, description: "PNG image data" },
-    ],
-    curlPrefix: `curl https://pixelrag.ai/api/tile`,
-    defaultParams: "article_id=2840114&tile_index=0&chunk_index=0",
-    buildPath: (_body, params) => {
-      const p = new URLSearchParams(params)
-      return `/tile/${p.get("article_id") || "2840114"}/${p.get("tile_index") || "0"}/${p.get("chunk_index") || "0"}`
-    },
   },
   {
     id: "health",
@@ -364,15 +364,20 @@ function OverviewSection({ onSelect }: { onSelect: (id: string) => void }) {
         Search, then fetch the top hit&apos;s screenshot:
       </p>
       <ShellBlock
-        code={`# 1 — search (text or image query)
+        code={`# 1 — search with a text query
 curl -X POST https://pixelrag.ai/api/search \\
   -H "Content-Type: application/json" \\
   -d '{"queries": [{"text": "How does photosynthesis work?"}], "n_docs": 5}'
 
-# → hits[0] = { "article_id": 2840114, "tile_index": 0, "chunk_index": 0, ... }
+# → hits[0] = { "article_id": 5878188, "tile_index": 1, "chunk_index": 0, ... }
 
 # 2 — fetch that hit's screenshot
-curl https://pixelrag.ai/api/tile/2840114/0/0 --output tile.png`}
+curl https://pixelrag.ai/api/tile/5878188/1/0 --output tile.png
+
+# 3 — or search with an image: base64-encode any local file inline
+curl -X POST https://pixelrag.ai/api/search \\
+  -H "Content-Type: application/json" \\
+  -d "{\\"queries\\": [{\\"image\\": \\"$(base64 < photo.jpg | tr -d '\\n')\\"}], \\"n_docs\\": 5}"`}
       />
 
       <h2 className="mt-10 text-xs font-semibold uppercase tracking-wider text-muted-foreground">


### PR DESCRIPTION
## What

- **`/tile` endpoint listing**: show the parameterized path `/tile/{article_id}/{tile_index}/{chunk_index}` in the sidebar/endpoint list instead of a hardcoded concrete ID, and move it up next to `/search` (it's step 2 of the search flow; `/status` and `/health` go after).
- **Fix wrong example IDs**: the docs claimed tile `2840114/0/0` is the top of the Albert Einstein article — it's actually `Fresno_State–Hawaii_football_rivalry`. Einstein is `698618/0/0` (verified by fetching the tile). The quickstart's photosynthesis example now shows the **real** top hit (`5878188/1/0`, the Photosynthesis article — verified live).
- **Image-query example**: add a copy-pasteable one-liner that base64-encodes a local file inline and POSTs it:
  ```bash
  curl -X POST https://pixelrag.ai/api/search \
    -H "Content-Type: application/json" \
    -d "{\"queries\": [{\"image\": \"$(base64 < photo.jpg | tr -d '\n')\"}], \"n_docs\": 5}"
  ```
  (`base64 < file | tr -d '\n'` is portable across Linux and macOS.)

## Verification

- `tsc --noEmit` passes.
- The image-query example was executed **verbatim as rendered** against the live API; querying with a thumbnail of a tile returns the tile's source article among the top hits.
- Both new example tiles (`698618/0/0` Einstein, `5878188/1/0` Photosynthesis) fetched and visually confirmed.