### PR TITLE
feat(web): ask examples that ChatGPT verifiably gets wrong

### DIFF
--- a/web/app/chat/page.tsx
+++ b/web/app/chat/page.tsx
@@ -56,9 +56,9 @@ interface ChatMessage {
 }
 
 const EXAMPLES = [
-  { q: "Explain Van Gogh's The Starry Night", icon: "01" },
-  { q: "How do you read the periodic table?", icon: "02" },
-  { q: "Tell me about the Taj Mahal", icon: "03" },
+  { q: "How many shots on target did Inter have in the 2010 Champions League final?", icon: "01" },
+  { q: "Which district in Nagaland has the RTO code NL-03?", icon: "02" },
+  { q: "Explain Van Gogh's The Starry Night", icon: "03" },
   { q: "介绍一下兵马俑", icon: "04" },
 ]
 

--- a/web/components/SearchBar.tsx
+++ b/web/components/SearchBar.tsx
@@ -19,10 +19,13 @@ const EXAMPLE_QUERIES = [
   "兵马俑",
 ]
 
+// The first two are verified "ChatGPT gets these wrong" questions: the answers
+// live in table/infobox cells (match-stats table, RTO code box) that parametric
+// memory and text scraping both fumble — but reading the rendered page nails.
 const ASK_EXAMPLES = [
+  "How many shots on target did Inter have in the 2010 Champions League final?",
+  "Which district in Nagaland has the RTO code NL-03?",
   "Explain Van Gogh's The Starry Night",
-  "How do you read the periodic table?",
-  "Tell me about the Taj Mahal",
   "介绍一下兵马俑",
 ]
 


### PR DESCRIPTION
Tested 23 SimpleQA-style candidates against Codex (GPT-5-class) as the 'ChatGPT control group'. Modern models have memorized nearly all public-benchmark prose facts — the survivors are **table/infobox cells**:

| question | ChatGPT no-web | ChatGPT **with web** | our agent (live, verified) |
|---|---|---|---|
| Inter shots on target, 2010 UCL final | 4 ❌ | **4 ❌ (cites UEFA/Wikipedia!)** | **7 ✅** reads the stats table tile |
| Nagaland RTO code NL-03 | Kohima ❌ | Tuensang ✅ | **Tuensang ✅** triangulates district infoboxes |

The shots question is the flagship: wrong even with browsing, because text extraction mangles the multi-column match-stats table — exactly the failure mode the paper's pipeline figure illustrates. Kept 'Explain The Starry Night' + '介绍一下兵马俑' for approachability.