### PR TITLE
docs: point public examples at https://api.pixelrag.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ The two core operations — **render** a page to screenshots, **search** a visua
 pixelshot https://en.wikipedia.org/wiki/Python --output ./tiles
 
 # Search a hosted index of 8.28M Wikipedia pages — no setup, runs against the live API
-curl -X POST http://api.pixelrag.ai:30001/search \
+curl -X POST https://api.pixelrag.ai/search \
   -H "Content-Type: application/json" \
   -d '{"queries": [{"text": "What is the capital of France?"}], "n_docs": 5}'
 ```
 
-> **Live, hosted endpoint** — [`http://api.pixelrag.ai:30001`](http://api.pixelrag.ai:30001/status) serves a
+> **Live, hosted endpoint** — [`https://api.pixelrag.ai`](https://api.pixelrag.ai/status) serves a
 > pre-built index of **8.28M Wikipedia pages**. No setup, no API key. It even takes an image as the query
 > ([visual search](https://pixelrag.ai/docs#search)) — see the **[API reference →](https://pixelrag.ai/docs)**.
 

--- a/demos/quickstart.ipynb
+++ b/demos/quickstart.ipynb
@@ -165,7 +165,7 @@
     "import requests\n",
     "from IPython.display import Image, display\n",
     "\n",
-    "API = \"http://api.pixelrag.ai:30001\"\n",
+    "API = \"https://api.pixelrag.ai\"\n",
     "hits = requests.post(\n",
     "    f\"{API}/search\", json={\"queries\": [{\"text\": \"兵马俑\"}], \"n_docs\": 2}\n",
     ").json()[\"results\"][0][\"hits\"]\n",

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -385,7 +385,7 @@ curl -X POST https://pixelrag.ai/api/search \\
       </h2>
       <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">
         <Code>https://pixelrag.ai/api</Code> — or query the index server directly at{" "}
-        <Code>http://api.pixelrag.ai:30001</Code>.
+        <Code>https://api.pixelrag.ai</Code>.
       </p>
 
       <h2 className="mt-10 text-xs font-semibold uppercase tracking-wider text-muted-foreground">


### PR DESCRIPTION
Replaces the last `http://api.pixelrag.ai:30001` references (README hero curl + callout, API docs Base URL, quickstart notebook) with `https://api.pixelrag.ai` — TLS, goes through the nginx upstream, and follows blue-green switches. Self-hosting examples keep `localhost`.