### PR TITLE
feat(web): swap 兵马俑 search example for 清明上河图

### DIFF
--- a/web/components/SearchBar.tsx
+++ b/web/components/SearchBar.tsx
@@ -16,7 +16,7 @@ const EXAMPLE_QUERIES = [
   "Periodic table",
   "Taj Mahal",
   "The Great Wave off Kanagawa",
-  "兵马俑",
+  "清明上河图",
 ]
 
 // The first two are verified "ChatGPT gets these wrong" questions: the answers


### PR DESCRIPTION
Screened 8 Chinese candidates on the live LoRA backend: ① cross-lingual hit on the right article, ② live-grid visual impact. 长城 failed retrieval outright; 京剧/莫高窟 too text-heavy; **清明上河图** ranks the target #1 and the scroll's panorama bands repeat across nearly every group — a unified amber gallery. Keeps the Chinese-language showcase; ask-mode 介绍一下兵马俑 unchanged.