### PR TITLE
docs: Colab-ready quickstart notebook + Open in Colab badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ curl -X POST https://api.pixelrag.ai/search \
 > pre-built index of **8.28M Wikipedia pages**. No setup, no API key. It even takes an image as the query
 > ([visual search](https://pixelrag.ai/docs#search)) — see the **[API reference →](https://pixelrag.ai/docs)**.
 
-Or try it in the browser at **[pixelrag.ai](https://pixelrag.ai)**, or run the
-[demo notebook](demos/quickstart.ipynb) (renders + searches, with the images inline).
+Or try it in the browser at **[pixelrag.ai](https://pixelrag.ai)**, or run the demo notebook in
+Colab [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/StarTrail-org/PixelRAG/blob/main/demos/quickstart.ipynb) — it
+renders a page and searches the hosted index, with the images inline.
 
 ## What it is
 

--- a/demos/quickstart.ipynb
+++ b/demos/quickstart.ipynb
@@ -5,6 +5,8 @@
    "id": "f7e0c62d",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/StarTrail-org/PixelRAG/blob/main/demos/quickstart.ipynb)\n",
+    "\n",
     "# PixelRAG — Quickstart\n",
     "\n",
     "Visual Retrieval-Augmented Generation: render documents as **screenshots**, search them as **images**. This notebook shows both, with the actual pictures.\n",
@@ -12,6 +14,32 @@
     "```bash\n",
     "pip install pixelrag\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# One-time setup (~1 min). Needs Python >= 3.12 (Colab's default runtime).\n",
+    "# pixelshot's headless-Chrome renderer also needs a few system libs on a\n",
+    "# fresh Colab/Linux VM; the hosted search API needs nothing.\n",
+    "%pip install -q pixelrag\n",
+    "\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "if sys.platform == \"linux\" and shutil.which(\"apt-get\"):\n",
+    "    libs = (\n",
+    "        \"libnss3 libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 \"\n",
+    "        \"libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libasound2\"\n",
+    "    )\n",
+    "    subprocess.run(f\"apt-get -qq install -y {libs}\", shell=True, check=False)\n",
+    "\n",
+    "print(\"ready\")"
    ]
   },
   {
@@ -180,6 +208,9 @@
   }
  ],
  "metadata": {
+  "colab": {
+   "name": "PixelRAG Quickstart"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
We had `demos/quickstart.ipynb` (render + hosted-search, images inline) but no Colab entry point. Made it runnable on Colab:

- **Setup cell:** `%pip install pixelrag` + the chrome system libs a fresh VM needs (`pixelshot` auto-downloads the patched headless Chrome itself). The hosted-search half needs zero setup.
- **Open in Colab badge** in the notebook header + README.

Verified: `pip install pixelrag` → `pixelshot` renders a real Wikipedia page end-to-end in a clean venv; Colab's default runtime is Python 3.12.13 and the package requires ≥3.12 ✓. ruff-clean, valid nbformat.