### PR TITLE
fix(render): wait for load + scroll per tile in CDP backend (fixes blank SPA / below-fold tiles)

### DIFF
--- a/docs/internal/screenshot-optimization-notes.md
+++ b/docs/internal/screenshot-optimization-notes.md
@@ -182,3 +182,58 @@ Lab machines have 8× H200/B200 GPUs but:
 
 To unlock GPU: `sudo usermod -aG render $USER` on lab machine.
 Expected impact: 4x faster DrawRenderPass based on production system data.
+
+## Backend reconciliation & SPA-render fix (2026-06-11)
+
+### The three render code paths (who actually runs what)
+- `backends/websocket.py` — the **shipped** general-purpose renderer. The `pixelshot`
+  CLI, the `pixelbrowse` skill, and the `pixelrag index` pipeline (`render_urls`,
+  `backend="cdp"`/`"websocket"`) all go through it. Simple: per-worker queue, inline
+  JPEG over CDP, no extra deps.
+- `backends/fast_cdp.py` — high-throughput batch path (`render_articles`): phased-logic
+  capture + rawFilePath to /dev/shm + ProcessPool JPEG. **No in-repo caller** — invoked
+  only by an out-of-repo ops script. The 8.28M flagship Wikipedia index was built by a
+  *separate* system (Playwright/GPU/4-machine, see "Production System Comparison"), not
+  by either of these.
+- `strategies/*` — the benchmarking menu; used only by `bench/`. Kept as research scaffolding.
+
+### Regression fixed: websocket backend rendered SPAs / tall pages wrong
+`backends/websocket.py` had drifted from the established capture pattern — it had **no
+nav-completion wait** (fired `document.fonts.ready` immediately after `Page.navigate`)
+and **no per-tile scroll**, both of which `fast_cdp` and the production strategies have.
+Consequences:
+- JS/SPA pages were measured/captured mid-hydration at a transient (often much taller)
+  layout → tiled into mostly-empty space = blank tiles (this is the "tile loop overshoots
+  page height" blank bug noted under "Production System Comparison", here root-caused).
+- At small `tile_height` (the skill uses 1568) every tile past the first was blank,
+  because content below the short device viewport is never rasterized without scrolling.
+
+Fix (verified in `bench/` against ground truth at 100% on the smoke set):
+- Wait for the `load` event before measuring/capturing (`readyState==='complete'`
+  shortcut + 12s cap). SSR pages fire `load` ~as fast as `fonts.ready`, so ~0 cost
+  (measured: Wikipedia render time unchanged).
+- Scroll each tile into view before capture (mirrors `fast_cdp`).
+- Optional `--wait-network-idle` (JS PerformanceObserver) for pages that fetch content
+  after load; off by default (costs a quiet window/page), on by default in the skill.
+
+### Raw vs inline-JPEG is the dominant throughput lever (measured, 48w, N=600, this box)
+| config | correct | t/s | note |
+|---|---|---|---|
+| phased **raw** (fast_cdp config) | 99.7% | **306** | capture-only in bench; JPEG is decoupled/parallel |
+| phased jpeg (inline) | 98.2% | 182 | Chrome encodes JPEG on the capture critical path |
+| sequential raw | 99.7% | 221 | |
+| sequential jpeg (inline) | 98.2% | 142 | |
+
+Takeaways: (1) **inline JPEG encoding is the bottleneck** — bypassing it with rawFilePath
++ parallel compression is ~+56-68%. (2) phased's semaphore/work-stealing buys ~+38% over
+sequential **in raw mode** (in jpeg mode the encoding bottleneck masks it to ~+8% — an
+earlier jpeg-only comparison was misleading). So `fast_cdp` is ~2x the simple inline path
+at batch scale and is **kept**. Absolute t/s here is optimistic (capture-only, short
+window, 128-core box) vs the ~91-113 production figure; the *ratios* are the point.
+
+### Design direction
+Ship **one simple backend** (`websocket.py`, inline JPEG) for the CLI/skill/`pixelrag index`
+— that scale doesn't need the raw+decoupled machinery, and the flagship index uses the
+separate system anyway. Keep `fast_cdp` + `strategies/` as batch/research code. The shared
+capture-readiness logic (load wait, scroll) should eventually live in one place so the
+shipped backend can't silently drift from the correct pattern again.

--- a/plugin/skills/pixelbrowse/SKILL.md
+++ b/plugin/skills/pixelbrowse/SKILL.md
@@ -17,13 +17,13 @@ Use `pixelshot` to capture any URL or document as tiled JPEG images, then read t
 
 ```bash
 # Screenshot a URL (optimized for Claude's vision: 1568px tile height)
-pixelshot <url> --output /tmp/pixelbrowse --tile-height 1568
+pixelshot <url> --output /tmp/pixelbrowse --tile-height 1568 --wait-network-idle
 
 # Screenshot multiple URLs in parallel
-pixelshot <url1> <url2> --output /tmp/pixelbrowse --tile-height 1568 --workers 4
+pixelshot <url1> <url2> --output /tmp/pixelbrowse --tile-height 1568 --wait-network-idle --workers 4
 
 # Wider viewport for desktop layouts
-pixelshot <url> --output /tmp/pixelbrowse --tile-height 1568 --viewport-width 1280
+pixelshot <url> --output /tmp/pixelbrowse --tile-height 1568 --viewport-width 1280 --wait-network-idle
 
 # Render a PDF
 pixelshot document.pdf --output /tmp/pixelbrowse
@@ -33,11 +33,16 @@ IMPORTANT: Always use `--tile-height 1568` for screenshots you will read visuall
 Claude's vision model downscales images with long edge > 1568px (Sonnet/Haiku) or 2576px (Opus).
 The default 8192px tile height will be downscaled and text becomes unreadable.
 
+IMPORTANT: Always use `--wait-network-idle` for URLs. Without it, JavaScript-heavy
+pages (most modern sites / single-page apps) are captured before they finish rendering
+and come back blank or half-empty. It waits for the page's load event plus a brief
+network-quiet window so client-rendered content is actually on screen.
+
 After rendering, read the tile images from the output directory to visually understand the content.
 
 ## Workflow
 
-1. Run `pixelshot <url> --output /tmp/pixelbrowse`
+1. Run `pixelshot <url> --output /tmp/pixelbrowse --tile-height 1568 --wait-network-idle`
 2. Read `/tmp/pixelbrowse/<domain>.png.tiles/tile_0000.jpg` directly (no need to ls — the naming is deterministic)
 3. If the page is long, also read tile_0001.jpg, tile_0002.jpg, etc.
 

--- a/render/src/pixelrag_render/backends/websocket.py
+++ b/render/src/pixelrag_render/backends/websocket.py
@@ -85,6 +85,89 @@ async def _cdp_send(ws, msg_id_ref: list, method: str, params: dict | None = Non
             return r.get("result", {})
 
 
+# Max time to wait for the `load` event (and for the optional network-idle wait)
+# before giving up and capturing whatever is there. Keeps a hanging page from
+# stalling a worker.
+LOAD_TIMEOUT_MS = 12_000
+# Network is considered idle once no new resource has been fetched for this long.
+NET_QUIET_MS = 500
+
+
+def _readiness_expr(wait_network_idle: bool) -> str:
+    """Build the in-page readiness probe.
+
+    Always waits for the `load` event before measuring (with a
+    ``readyState === 'complete'`` shortcut so an already-loaded page returns
+    immediately, and a hard timeout so a hanging page can't block). Without this,
+    a client-rendered (SPA) page is measured/captured mid-hydration at a transient
+    layout — often much taller than the settled page — producing blank tiles. SSR
+    pages (e.g. Wikipedia) fire `load` almost immediately, so this adds ~no cost.
+
+    When ``wait_network_idle`` is set, also waits (after load) until no new
+    resource has been fetched for ``NET_QUIET_MS`` — for SPAs that fetch their
+    content *after* load. This costs a quiet window per page, so it is opt-in
+    (the pixelbrowse skill / single-page renders), not the batch default.
+
+    Returns an async-IIFE expression resolving to the page height to tile.
+    """
+    idle_step = ""
+    if wait_network_idle:
+        idle_step = f"""
+        await new Promise(res => {{
+            let timer;
+            let obs;
+            const finish = () => {{ try {{ obs && obs.disconnect(); }} catch (e) {{}}
+                                    clearTimeout(timer); clearTimeout(hard); res(); }};
+            const bump = () => {{ clearTimeout(timer); timer = setTimeout(finish, {NET_QUIET_MS}); }};
+            try {{
+                obs = new PerformanceObserver(bump);
+                obs.observe({{ type: 'resource', buffered: true }});
+            }} catch (e) {{}}
+            const hard = setTimeout(finish, {LOAD_TIMEOUT_MS});
+            bump();
+        }});"""
+    return f"""(async () => {{
+        await new Promise(res => {{
+            if (document.readyState === 'complete') return res();
+            const t = setTimeout(res, {LOAD_TIMEOUT_MS});
+            window.addEventListener('load', () => {{ clearTimeout(t); res(); }}, {{ once: true }});
+        }});{idle_step}
+        await document.fonts.ready;
+        await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+        document.documentElement.style.scrollBehavior = 'auto';
+        const sh = document.documentElement.scrollHeight;
+        const body = document.body;
+        if (body) {{
+            const bottom = Math.ceil(body.getBoundingClientRect().bottom);
+            return Math.min(sh, Math.max(bottom, 1));
+        }}
+        return sh;
+    }})()"""
+
+
+# Before capturing a tile below the first one, scroll it into view and wait for
+# its now-visible images to load. The capture clip uses absolute page coordinates,
+# but Chrome only rasterizes content near the viewport — without scrolling, tiles
+# past the first (e.g. on a small tile_height) come back blank. Mirrors fast_cdp.
+_SCROLL_WAIT = """new Promise(resolve => {{
+    window.scrollTo(0, {y});
+    requestAnimationFrame(() => requestAnimationFrame(() => {{
+        const imgs = Array.from(document.images).filter(i => {{
+            if (i.complete) return false;
+            const r = i.getBoundingClientRect();
+            return r.bottom > 0 && r.top < window.innerHeight;
+        }});
+        if (imgs.length === 0) return resolve();
+        const timeout = new Promise(r => setTimeout(r, 500));
+        const loaded = Promise.all(imgs.map(i => new Promise(r => {{
+            i.addEventListener('load', r, {{once: true}});
+            i.addEventListener('error', r, {{once: true}});
+        }})));
+        Promise.race([loaded, timeout]).then(resolve);
+    }}));
+}})"""
+
+
 async def capture_url(
     ws,
     msg_id_ref: list,
@@ -96,6 +179,7 @@ async def capture_url(
     viewport_w: int = VIEWPORT_W,
     image_format: str = "jpeg",
     from_surface: bool = True,
+    wait_network_idle: bool = False,
 ) -> int:
     """Capture a URL as tiled images via direct CDP websocket.
 
@@ -105,29 +189,14 @@ async def capture_url(
 
     await _cdp_send(ws, msg_id_ref, "Page.navigate", {"url": url})
 
-    # Wait for fonts + layout to stabilize, return scrollHeight in one call
+    # Wait for load (+ optional network-idle) + fonts + layout to stabilize,
+    # return the page height to tile in one call. See _readiness_expr.
     result = await _cdp_send(
         ws,
         msg_id_ref,
         "Runtime.evaluate",
         {
-            "expression": """new Promise(resolve => {
-            document.fonts.ready.then(() => {
-                requestAnimationFrame(() => {
-                    requestAnimationFrame(() => {
-                        document.documentElement.style.scrollBehavior = 'auto';
-                        const sh = document.documentElement.scrollHeight;
-                        const body = document.body;
-                        if (body) {
-                            const bottom = Math.ceil(body.getBoundingClientRect().bottom);
-                            resolve(Math.min(sh, Math.max(bottom, 1)));
-                        } else {
-                            resolve(sh);
-                        }
-                    });
-                });
-            });
-        })""",
+            "expression": _readiness_expr(wait_network_idle),
             "awaitPromise": True,
             "returnByValue": True,
         },
@@ -145,6 +214,19 @@ async def capture_url(
         clip_h = min(tile_h, page_height - y)
         if clip_h <= 0:
             break
+
+        # Scroll the tile into view so Chrome rasterizes it (tiles past the first
+        # are otherwise blank). The top tile is already in view after load.
+        if idx > 0:
+            try:
+                await _cdp_send(
+                    ws,
+                    msg_id_ref,
+                    "Runtime.evaluate",
+                    {"expression": _SCROLL_WAIT.format(y=y), "awaitPromise": True},
+                )
+            except Exception:
+                pass
 
         params = {
             "format": image_format,
@@ -205,6 +287,7 @@ async def _worker(
     viewport_w: int,
     image_format: str,
     from_surface: bool,
+    wait_network_idle: bool,
     worker_id: int,
     stats: dict,
     results: list,
@@ -224,6 +307,10 @@ async def _worker(
         msg_id_ref = [0]
 
         await _cdp_send(ws, msg_id_ref, "Page.enable")
+        if wait_network_idle:
+            # PerformanceObserver (used by the idle wait) needs no CDP domain, but
+            # enabling Network keeps resource timing reliable across navigations.
+            await _cdp_send(ws, msg_id_ref, "Network.enable")
         await _cdp_send(
             ws,
             msg_id_ref,
@@ -258,6 +345,7 @@ async def _worker(
                     viewport_w=viewport_w,
                     image_format=image_format,
                     from_surface=from_surface,
+                    wait_network_idle=wait_network_idle,
                 )
                 stats["done"] += 1
                 elapsed = time.monotonic() - t0
@@ -287,6 +375,7 @@ async def _run_batch(
     viewport_w: int,
     image_format: str,
     from_surface: bool,
+    wait_network_idle: bool,
     stems: list[str] | None,
     chrome_path: str,
 ) -> list[Path]:
@@ -329,6 +418,7 @@ async def _run_batch(
             viewport_w,
             image_format,
             from_surface,
+            wait_network_idle,
             wid,
             stats,
             results,
@@ -352,6 +442,7 @@ def render_urls(
     workers: int = 4,
     image_format: str = "jpeg",
     from_surface: bool = True,
+    wait_network_idle: bool = False,
     chrome_path: str | None = None,
 ) -> list[Path]:
     """Render URLs to tiled images using direct CDP websocket.
@@ -370,6 +461,11 @@ def render_urls(
         image_format: 'jpeg' or 'png' (default 'jpeg').
         from_surface: CDP fromSurface param. True for batch (throughput),
                       False for serve (low latency). Default True.
+        wait_network_idle: After the load event, also wait until the network has
+                      been quiet (no new resources) for ~500ms before capturing.
+                      Helps SPAs that fetch content after load; costs a quiet
+                      window per page, so it is off by default (batch throughput)
+                      and meant for single-page / interactive renders.
         chrome_path: Path to Chrome binary. Auto-detected if None.
 
     Returns:
@@ -393,6 +489,7 @@ def render_urls(
             viewport_width,
             image_format,
             from_surface,
+            wait_network_idle,
             stems,
             chrome,
         )

--- a/render/src/pixelrag_render/render.py
+++ b/render/src/pixelrag_render/render.py
@@ -277,6 +277,14 @@ def main() -> None:
         help="Browser viewport width in pixels (default: 875).",
     )
     parser.add_argument(
+        "--wait-network-idle",
+        action="store_true",
+        help="After the page's load event, also wait until the network is quiet "
+        "(~500ms) before capturing. Helps JS/SPA pages that fetch content after "
+        "load; adds a quiet window per page, so off by default. Recommended for "
+        "single-page renders (e.g. the pixelbrowse skill).",
+    )
+    parser.add_argument(
         "--dpi",
         type=int,
         default=200,
@@ -313,6 +321,7 @@ def main() -> None:
             quality=args.quality,
             viewport_width=args.viewport_width,
             workers=args.workers,
+            wait_network_idle=args.wait_network_idle,
         )
         results.extend(tile_dirs)
 
@@ -334,6 +343,7 @@ def main() -> None:
                     quality=args.quality,
                     viewport_width=args.viewport_width,
                     workers=1,
+                    wait_network_idle=args.wait_network_idle,
                 )
             elif suffix in {".png", ".jpg", ".jpeg", ".webp"}:
                 tile_dirs = render_file(fpath, output_dir)


### PR DESCRIPTION
## Problem
The websocket CDP backend (`backends/websocket.py`) — used by the `pixelshot` CLI, the `pixelbrowse` skill, and the `pixelrag index` pipeline — captured JS/SPA and tall pages incorrectly:

- It fired `document.fonts.ready` **immediately after** `Page.navigate`, with no nav-completion wait. On client-rendered pages this measured/captured a **transient pre-hydration layout** (much taller than the settled page) → the page was tiled into mostly-empty space = blank tiles.
- It **never scrolled** between tiles. At a small `--tile-height` (the skill uses `1568`), the device viewport is short, so content below the first tile is never rasterized → every tile past the first came back blank.

Both behaviors had drifted from the pattern the batch renderer (`fast_cdp`) and the production strategies already use (nav-completion wait + per-tile scroll).

## Fix
- **Wait for the `load` event** before measuring height + capturing (`readyState === 'complete'` shortcut + 12s cap). SSR pages fire `load` ~as fast as `fonts.ready`, so this adds ~no cost (Wikipedia render time unchanged in measurement).
- **Scroll each tile into view** before capture (mirrors `fast_cdp`).
- Add opt-in **`--wait-network-idle`** (JS `PerformanceObserver`) for pages that fetch content *after* `load`; off by default (costs a network-quiet window per page), enabled by default in the `pixelbrowse` skill.

## Validation
- Ran the patched backend **inside the bench harness** against ground truth: **100%** correct on the smoke set; the larger run's lone miss is a marginal `mean_diff 5.61` vs a `5.0` JPEG threshold on one page whose image settles between `fonts.ready` and `load` (i.e. the patched render is the *more* settled one).
- Controlled A/B on a local ZIM corpus through the real `render_urls` path: load-wait adds **~0** to Wikipedia throughput (`load`-mode ≈ baseline); `--wait-network-idle` is the only mode with a per-page cost, hence opt-in.
- `pytest tests/test_render.py` green; `ruff` clean.

## Files
- `render/src/pixelrag_render/backends/websocket.py` — load-wait + per-tile scroll + `wait_network_idle`
- `render/src/pixelrag_render/render.py` — `--wait-network-idle` flag
- `plugin/skills/pixelbrowse/SKILL.md` — enable the flag by default
- `docs/internal/screenshot-optimization-notes.md` — document the fix + backend reconciliation