### PR TITLE
fix(render): cap requestAnimationFrame waits (headless rAF hang)

### DIFF
--- a/render/src/pixelrag_render/backends/cdp.py
+++ b/render/src/pixelrag_render/backends/cdp.py
@@ -141,7 +141,13 @@ def _readiness_expr(wait_network_idle: bool) -> str:
             window.addEventListener('load', () => {{ clearTimeout(t); res(); }}, {{ once: true }});
         }});{idle_step}
         await document.fonts.ready;
-        await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+        // Let layout settle over two frames — but cap it: requestAnimationFrame
+        // never ticks in some headless modes (e.g. google-chrome --headless=new
+        // with no compositor frames scheduled), where awaiting rAF would hang.
+        await Promise.race([
+            new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r))),
+            new Promise(r => setTimeout(r, 1000)),
+        ]);
         document.documentElement.style.scrollBehavior = 'auto';
         const sh = document.documentElement.scrollHeight;
         const body = document.body;
@@ -159,6 +165,9 @@ def _readiness_expr(wait_network_idle: bool) -> str:
 # past the first (e.g. on a small tile_height) come back blank. Mirrors fast_cdp.
 _SCROLL_WAIT = """new Promise(resolve => {{
     window.scrollTo(0, {y});
+    // Safety net: requestAnimationFrame may never tick in headless modes that
+    // don't schedule frames, which would leave this promise unresolved.
+    setTimeout(resolve, 1500);
     requestAnimationFrame(() => requestAnimationFrame(() => {{
         const imgs = Array.from(document.images).filter(i => {{
             if (i.complete) return false;


### PR DESCRIPTION
## What
The readiness probe and per-tile scroll `await` `requestAnimationFrame`. rAF **never ticks** in headless modes that don't schedule compositor frames (e.g. google-chrome `--headless=new`), so those awaits hang forever. Race each rAF wait against a short `setTimeout` fallback — fires in ~16ms where rAF ticks, falls through after a short delay otherwise.

## Root-cause investigation (google-chrome 149 standard-path hang)
Step-traced the CDP sequence on google-chrome `--headless=new`:
- `connect / Page.enable / setDeviceMetrics / navigate` → all OK
- `readiness` → **hung** (rAF doesn't tick) → **this PR fixes it** (now ~1s via fallback)
- `captureScreenshot` → still **hangs** — google-chrome produces no compositor frame to capture here, with **any** `--headless` flag and even minimal args.

So stock google-chrome isn't a viable capture binary in this headless setup — which is precisely what the patched `headless_shell` (ForceRedraw) was built to solve. `find_chrome` already prefers the patched binary (auto-installed default) and Playwright Chromium over system google-chrome, so real users aren't on this path. Making stock google-chrome capture would require frame-driving (beginFrame/ForceRedraw); out of scope here.

## Verified
- Standard path on Playwright Chromium and turbo path on the patched `headless_shell`: unaffected (3.4s).
- `ruff` (check + format) and `tests/test_render.py`: green.