### PR TITLE
feat(api): add request ID middleware for log tracing

### DIFF
--- a/serve/src/pixelrag_serve/api.py
+++ b/serve/src/pixelrag_serve/api.py
@@ -33,6 +33,7 @@ Usage:
 
 import argparse
 import base64
+import contextvars
 import functools
 import io
 import json
@@ -40,19 +41,33 @@ import logging
 import os
 import re
 import time
+import uuid
 from datetime import datetime, timezone
 
 import faiss
 import numpy as np
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 from PIL import Image
 from pydantic import BaseModel
 
+_request_id_ctx: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "request_id", default="-"
+)
+
+
+class _RequestIDFilter(logging.Filter):
+    def filter(self, record):
+        record.req = _request_id_ctx.get()
+        return True
+
+
 logger = logging.getLogger("search_api")
+logger.addFilter(_RequestIDFilter())
 logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: [%(req)s] %(message)s",
 )
 
 app = FastAPI(title="PixelRAG Search API")
@@ -64,6 +79,18 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def _request_id_middleware(request: Request, call_next):
+    req_id = request.headers.get("X-Request-ID") or uuid.uuid4().hex[:12]
+    token = _request_id_ctx.set(req_id)
+    try:
+        response: Response = await call_next(request)
+    finally:
+        _request_id_ctx.reset(token)
+    response.headers["X-Request-ID"] = req_id
+    return response
 
 # Global state loaded at startup
 _state = {}

--- a/serve/src/pixelrag_serve/api.py
+++ b/serve/src/pixelrag_serve/api.py
@@ -112,10 +112,9 @@ async def _request_id_middleware(request: Request, call_next):
     correlate client-side and server-side traces.
     """
     incoming = request.headers.get("X-Request-ID")
-    req_id = (
-        _sanitize_request_id(incoming) if incoming
-        else uuid.uuid4().hex[:16]
-    )
+    # A malformed incoming ID sanitises to None — fall back to a fresh ID
+    # rather than letting None reach the ContextVar / response header.
+    req_id = (incoming and _sanitize_request_id(incoming)) or uuid.uuid4().hex[:16]
     token = _request_id_ctx.set(req_id)
     try:
         response: Response = await call_next(request)
@@ -123,6 +122,7 @@ async def _request_id_middleware(request: Request, call_next):
         return response
     finally:
         _request_id_ctx.reset(token)
+
 
 # Global state loaded at startup
 _state = {}

--- a/serve/src/pixelrag_serve/api.py
+++ b/serve/src/pixelrag_serve/api.py
@@ -53,18 +53,37 @@ from PIL import Image
 from pydantic import BaseModel
 
 _request_id_ctx: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "request_id", default="-"
+    "request_id",
+    default="-",
 )
+"""Per-request tracing ID, propagated across async context switches."""
+
+
+def _sanitize_request_id(raw: str) -> str | None:
+    """Return *raw* if it looks safe (≤64 chars, alphanumeric + ``-_``), else None."""
+    if len(raw) > 64:
+        return None
+    if raw.replace("-", "").replace("_", "").isalnum():
+        return raw.strip()
+    return None
 
 
 class _RequestIDFilter(logging.Filter):
+    """Logging filter that injects the current request ID into every record.
+
+    Registered on the root logger so that third-party loggers (uvicorn,
+    httpx, …) also see a ``[-]`` placeholder instead of crashing on
+    ``%(req)s`` in the format string.
+    """
+
     def filter(self, record):
         record.req = _request_id_ctx.get()
         return True
 
 
+logging.getLogger().addFilter(_RequestIDFilter())
+
 logger = logging.getLogger("search_api")
-logger.addFilter(_RequestIDFilter())
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(name)s: [%(req)s] %(message)s",
@@ -83,14 +102,27 @@ app.add_middleware(
 
 @app.middleware("http")
 async def _request_id_middleware(request: Request, call_next):
-    req_id = request.headers.get("X-Request-ID") or uuid.uuid4().hex[:12]
+    """Inject a per-request tracing ID into logs and the response header.
+
+    Reads ``X-Request-ID`` from the incoming request (sanitised), or
+    generates a fresh 16-hex-char ID.  The ID is stored in a
+    :class:`contextvars.ContextVar` so it flows through ``await``
+    boundaries and is picked up by :class:`_RequestIDFilter`.
+    The *response* always carries ``X-Request-ID`` so callers can
+    correlate client-side and server-side traces.
+    """
+    incoming = request.headers.get("X-Request-ID")
+    req_id = (
+        _sanitize_request_id(incoming) if incoming
+        else uuid.uuid4().hex[:16]
+    )
     token = _request_id_ctx.set(req_id)
     try:
         response: Response = await call_next(request)
+        response.headers["X-Request-ID"] = req_id
+        return response
     finally:
         _request_id_ctx.reset(token)
-    response.headers["X-Request-ID"] = req_id
-    return response
 
 # Global state loaded at startup
 _state = {}


### PR DESCRIPTION
Closes #40

Adds a per-request `X-Request-ID` via middleware + `contextvars`, so every log line can be traced back to its originating request.

### How it works

1. **Middleware** reads `X-Request-ID` header (or auto-generates), stores in `contextvars.ContextVar`
2. **Log filter** injects `[req_id]` into every log record — transparent to all existing `logger.info()` calls  
3. **Response header** returns `X-Request-ID` to the caller

### Log output

```
# Before
INFO search_api: Search: 1 query n_docs=5 encode=0.45s total=0.48s

# After  
INFO search_api: [a1b2c3d4e5f6] Search: 1 query n_docs=5 encode=0.45s total=0.48s
```

`contextvars` (not `threading.local`) is used because asyncio switches between coroutines — each request gets its own ID correctly even when `await` hops between concurrent handlers.