### PR TITLE
docs(pixelbrowse): recommend uv tool/pipx install (pixelshot on PATH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ The renderer also ships as a Claude Code plugin — the **pixelbrowse** skill. I
 raw HTML, Claude screenshots a page with `pixelshot` and _reads the image_, so it sees
 charts, diagrams, tables, and layout the way a person does.
 
-Install it — no clone needed (`pixelshot` comes from `pip install pixelrag`):
+Install it — no clone needed. Install the `pixelshot` CLI so it's on your `PATH`
+(use `uv tool` or `pipx` to keep it isolated yet always available to Claude — a
+plain `pip install` into a project venv may leave `pixelshot` off `PATH`):
 
 ```bash
-pip install pixelrag                                # provides the pixelshot command
+uv tool install pixelrag                            # pixelshot on PATH (or: pipx install pixelrag)
 claude plugin marketplace add StarTrail-org/PixelRAG
 claude plugin install pixelbrowse@pixelrag-plugins
 ```

--- a/plugin/skills/pixelbrowse/SKILL.md
+++ b/plugin/skills/pixelbrowse/SKILL.md
@@ -13,6 +13,10 @@ allowed-tools: "Bash, Read"
 
 Use `pixelshot` to capture any URL or document as tiled JPEG images, then read the images visually.
 
+Requires the `pixelshot` command on `PATH`. If `pixelshot` is not found, install it
+(isolated, on `PATH`): `uv tool install pixelrag` (or `pipx install pixelrag`, or
+`pip install pixelrag`) — then retry. Don't go hunting for it in project venvs.
+
 ## How to use
 
 ```bash


### PR DESCRIPTION
A plain `pip install pixelrag` into a project venv can leave `pixelshot` off `PATH` — so the pixelbrowse skill can't find it and the agent burns turns hunting (observed live). Recommend `uv tool install pixelrag` (or `pipx`) which keeps the CLI isolated yet always on `PATH`. Updates the README 'Give Claude eyes' block and adds a 'requires pixelshot on PATH / install with uv tool if missing' note to the skill so the agent self-heals instead of searching venvs. Docs only.