### PR TITLE
fix(embed): 2D-tile wide pages so PDFs/landscape content isn't dropped (#47)

### DIFF
--- a/embed/src/pixelrag_embed/chunk.py
+++ b/embed/src/pixelrag_embed/chunk.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
-"""Pre-chunk tile images into 1024px-height strips on disk.
+"""Pre-chunk tile images into model-sized pieces on disk.
 
-For each article directory (*.png.tiles/), reads every tile_XXXX.png,
-splits it into 1024px-tall chunks, writes chunk_XXXX_YY.png files,
-and saves a chunks.json manifest recording the mapping.
+For each article directory (*.png.tiles/), reads every tile_XXXX.png and splits
+it into a grid of <=1024px-tall x <=viewport_width-wide chunks (writing
+chunk_XXXX_YY.png files) plus a chunks.json manifest recording each chunk's
+x_offset/y_offset/width/height. Narrow web tiles (<= viewport_width) keep their
+old single-column height-strip layout; wider sources (PDFs, landscape pages) are
+also split along the width so the embedder never has to drop an oversized chunk.
 
 Usage:
     # Single shard
@@ -145,8 +148,9 @@ def chunk_article(article_dir: str, dry_run: bool = False, force: bool = False) 
             tile_base = tile_base.replace(ext, "")
         tile_idx = int(tile_base)
 
-        if h <= CHUNK_HEIGHT:
-            # No chunking needed — copy tile as chunk_XXXX_00.png
+        # Fast path: web tiles (<= viewport_width) that fit one strip are copied
+        # verbatim — byte-identical to the pre-2D-tiling behavior.
+        if w <= viewport_width and h <= CHUNK_HEIGHT:
             chunk_name = f"chunk_{tile_idx:04d}_00.png"
             chunk_path = os.path.join(article_dir, chunk_name)
             if not dry_run:
@@ -158,6 +162,7 @@ def chunk_article(article_dir: str, dry_run: bool = False, force: bool = False) 
                     "tile_index": tile_idx,
                     "chunk_index": 0,
                     "file": chunk_name,
+                    "x_offset": 0,
                     "y_offset": 0,
                     "height": h,
                     "width": w,
@@ -165,39 +170,48 @@ def chunk_article(article_dir: str, dry_run: bool = False, force: bool = False) 
             )
             continue
 
-        # Split into CHUNK_HEIGHT strips
-        y = 0
+        # 2D grid: CHUNK_HEIGHT-tall row strips x viewport_width-wide columns.
+        # Columns are a full viewport_width each (the model's native width) with
+        # the remainder in the last column — not evened out — so most content
+        # lands at the in-distribution width the index was built on. chunk_index
+        # is a flat row-major counter, so single-column tiles keep the same
+        # 0, 1, 2, ... order (and identical crops) as before.
         chunk_idx = 0
+        y = 0
         while y < h:
-            remaining = h - y
-            ch = min(CHUNK_HEIGHT, remaining)
-
-            # Discard tiny tail chunks (< 28px = one Qwen3-VL patch)
+            ch = min(CHUNK_HEIGHT, h - y)
+            # Discard tiny height tail (< 28px = one Qwen3-VL patch)
             if ch < MIN_CHUNK_HEIGHT:
                 break
 
-            chunk_name = f"chunk_{tile_idx:04d}_{chunk_idx:02d}.png"
-            chunk_path = os.path.join(article_dir, chunk_name)
+            x = 0
+            while x < w:
+                cw = min(viewport_width, w - x)
+                if cw < MIN_CHUNK_HEIGHT:  # discard tiny right-edge sliver
+                    break
 
-            if not dry_run:
-                crop = img.crop((0, y, w, y + ch))
-                crop.save(chunk_path, format="PNG")
-                files_written += 1
+                chunk_name = f"chunk_{tile_idx:04d}_{chunk_idx:02d}.png"
+                chunk_path = os.path.join(article_dir, chunk_name)
+                if not dry_run:
+                    img.crop((x, y, x + cw, y + ch)).save(chunk_path, format="PNG")
+                    files_written += 1
 
-            chunks_info.append(
-                {
-                    "tile": tile_name,
-                    "tile_index": tile_idx,
-                    "chunk_index": chunk_idx,
-                    "file": chunk_name,
-                    "y_offset": y,
-                    "height": ch,
-                    "width": w,
-                }
-            )
+                chunks_info.append(
+                    {
+                        "tile": tile_name,
+                        "tile_index": tile_idx,
+                        "chunk_index": chunk_idx,
+                        "file": chunk_name,
+                        "x_offset": x,
+                        "y_offset": y,
+                        "height": ch,
+                        "width": cw,
+                    }
+                )
+                chunk_idx += 1
+                x += cw
 
             y += ch
-            chunk_idx += 1
 
         img.close()
 

--- a/tests/test_chunk.py
+++ b/tests/test_chunk.py
@@ -1,0 +1,88 @@
+"""Chunking tests — 2D tiling keeps every chunk within the render width.
+
+The embedder skips any chunk wider than the render width (875px), so the chunker
+must split wide tiles (PDFs, landscape pages) along the width as well as the
+height. Narrow web tiles (<= viewport_width) must keep their old single-column
+height-strip layout unchanged so existing indexes stay reproducible.
+"""
+
+import json
+
+from PIL import Image
+
+from pixelrag_embed.chunk import CHUNK_HEIGHT, chunk_article
+
+
+def _make_tile(dir_path, w, h, viewport_width=None):
+    dir_path.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (w, h), (255, 255, 255)).save(dir_path / "tile_0000.png")
+    meta = {"tiles": ["tile_0000.png"], "tile_height": 8192}
+    if viewport_width is not None:
+        meta["viewport_width"] = viewport_width
+    (dir_path / "tiles.json").write_text(json.dumps(meta))
+    return dir_path
+
+
+def _chunks(dir_path):
+    return json.loads((dir_path / "chunks.json").read_text())["chunks"]
+
+
+def test_narrow_tile_unchanged(tmp_path):
+    # 875-wide tall web tile: single-column height strips, exactly as before.
+    d = _make_tile(tmp_path / "a.png.tiles", 875, 3000)
+    chunk_article(str(d))
+    cs = _chunks(d)
+    assert [c["file"] for c in cs] == [
+        "chunk_0000_00.png",
+        "chunk_0000_01.png",
+        "chunk_0000_02.png",
+    ]
+    assert [c["y_offset"] for c in cs] == [0, CHUNK_HEIGHT, 2 * CHUNK_HEIGHT]
+    assert all(c["x_offset"] == 0 and c["width"] == 875 for c in cs)
+
+
+def test_short_narrow_tile_copied_whole(tmp_path):
+    # <= viewport_width and <= CHUNK_HEIGHT: one chunk, tile copied verbatim.
+    d = _make_tile(tmp_path / "a.png.tiles", 600, 500)
+    chunk_article(str(d))
+    cs = _chunks(d)
+    assert len(cs) == 1
+    assert cs[0]["file"] == "chunk_0000_00.png"
+    assert cs[0]["width"] == 600 and cs[0]["height"] == 500
+
+
+def test_wide_tile_split_into_columns(tmp_path):
+    # Letter PDF at 200 DPI (~1700x2200): 2 columns x 3 rows, all <= 875 wide.
+    d = _make_tile(tmp_path / "a.png.tiles", 1700, 2200)
+    chunk_article(str(d))
+    cs = _chunks(d)
+    assert len(cs) == 6
+    assert all(c["width"] <= 875 for c in cs)
+    # every produced chunk file is on disk at its recorded size
+    for c in cs:
+        img = Image.open(d / c["file"])
+        assert img.size == (c["width"], c["height"])
+    # columns are full viewport_width (875) with the remainder last, covering
+    # the full width with no gaps
+    row0 = sorted((c for c in cs if c["y_offset"] == 0), key=lambda c: c["x_offset"])
+    assert [c["width"] for c in row0] == [875, 825]
+    assert row0[0]["x_offset"] == 0
+    assert row0[-1]["x_offset"] + row0[-1]["width"] == 1700
+
+
+def test_very_wide_tile_never_exceeds_width(tmp_path):
+    # 19-inch landscape figure (3800px): many columns, still all <= 875, no skips.
+    d = _make_tile(tmp_path / "a.png.tiles", 3800, 2200)
+    chunk_article(str(d))
+    cs = _chunks(d)
+    assert cs, "wide tile must still produce chunks (not be skipped)"
+    assert max(c["width"] for c in cs) <= 875
+
+
+def test_short_wide_tile_splits_width(tmp_path):
+    # Short but wide (was copied whole -> too wide -> skipped). Now splits width.
+    d = _make_tile(tmp_path / "a.png.tiles", 1700, 500)
+    chunk_article(str(d))
+    cs = _chunks(d)
+    assert len(cs) == 2
+    assert all(c["width"] <= 875 and c["height"] == 500 for c in cs)


### PR DESCRIPTION
## Problem

The embedder skips any chunk wider than the render width (875px), but the chunker only split tiles along the **height**. A PDF page rendered at the default 200 DPI (US Letter ~1700px wide) produced full-width 1700px chunks, all skipped -> `no embeddings produced`. Building an index from any PDF (or landscape/wide page) yielded zero embeddings.

## Fix

Split tiles along the **width** as well as the height: when a tile is wider than `viewport_width`, cut it into columns and tile in 2D (height row-strips x width columns).

- **Bounded memory** — per-chunk pixel/token budget unchanged (<= viewport_width x 1024); wide pages yield more chunks, not bigger ones. No OOM, no downscale.
- **Backward compatible** — narrow web tiles (<= viewport_width) keep the old single-column height-strip layout with identical crops/filenames; existing indexes stay reproducible.
- **No data loss** — wide content is split, not skipped or downscaled.

Manifest gains `x_offset` + per-column `width`. The embed `>875` skip is now a defensive guard (re-chunk with `--force` to recover pre-fix chunks).

## Design notes

**Columns are a full `viewport_width` (875) each, remainder in the last column — not evened out.** The retriever's LoRA was trained on 875px-wide tiles, so keeping most columns at exactly 875 maximizes the fraction of content at the in-distribution width; evening the columns (e.g. 1700 -> 850+850) would push *every* column off 875 for no benefit.

**Variable-size tiles are fine here.** PixelRAG uses a Qwen3-VL embedder (ColQwen2 family), whose native dynamic resolution + M-RoPE is *designed* to handle varying dimensions/aspect ratios without information loss. The index already mixes sizes (uniform 875 width, variable <=1024 height) and works; adding width variation is symmetric. So the odd remainder column is not a problem, and we deliberately **don't pad it to 875** (padding would dilute a narrow column's embedding with blank pixels and waste the token budget).

**No overlap by default.** Overlapping tiles would produce near-duplicate dense vectors that crowd the top-k (worse precision, larger index) — a poor trade for a 4TB / ~23M-vector corpus. If boundary-cut content ever needs it, a small *vertical-only* overlap knob plus retrieval-time dedup/MMR is the better path, validated on the eval harness.

## Tests

`tests/test_chunk.py`: narrow-tile-unchanged (byte-identical), short-narrow copied verbatim, wide PDF-size tile -> columns `[875, 825]`, very-wide 3800px stays <=875, short-wide splits width. Verified end-to-end on a real PDF (3800px page -> 10 chunks, max width 760, 0 skipped). No DPI change needed.
