### PR TITLE
fix: add fetch timeouts, improve UX (back button, chat lightbox), prevent agent loops

### DIFF
--- a/web/agent-server.mjs
+++ b/web/agent-server.mjs
@@ -23,7 +23,7 @@ import { query, tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk"
 import { z } from "zod"
 
 const PORT = parseInt(process.env.AGENT_PORT || "30010", 10)
-const SEARCH_URL = process.env.PIXELRAG_SEARCH_URL || "http://localhost:30001"
+const SEARCH_URL = process.env.PIXELRAG_SEARCH_URL || "https://api.pixelrag.ai"
 const MAX_BUDGET = parseFloat(process.env.CHAT_MAX_BUDGET_USD || "2.00")
 const THINKING_TOKENS = parseInt(process.env.CHAT_THINKING_TOKENS || "2000", 10)
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || "*"
@@ -63,7 +63,7 @@ For every user question, without exception:
 2. Call pixelrag_tile to VIEW the screenshot tiles of the top results — this is how you read and compare. View at least 2-3 tiles.
 3. Answer from what the tiles show, and cite the Wikipedia URLs. If the tiles don't contain the answer, say so honestly.
 
-Be decisive and efficient: for open-ended or comparison questions, check a few strong candidates (about 3-5), then commit to your best answer from what you have seen — do not keep searching indefinitely.
+Be decisive and efficient: view at most 4 tiles total across 1-2 articles, then commit to your best answer. If tiles are too small or blurry to read, say so and answer from the article titles/URLs. Do NOT keep retrying with different tiles or fall back to web search/fetch — you only have pixelrag_search and pixelrag_tile. Stop after 2 tile attempts that yield no readable text.
 
 Never skip search and tile — including for visual or comparison questions; always look at Wikipedia tiles first, even when you think you already know the answer.
 
@@ -100,6 +100,7 @@ function createTools(onEvent, uploadedImage) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ queries: [queryObj], n_docs: args.n_results ?? 5, articles_only: true }),
+        signal: AbortSignal.timeout(30000),
       })
       if (!resp.ok) {
         return { content: [{ type: "text", text: `Search API error: ${resp.status}` }] }
@@ -136,7 +137,7 @@ function createTools(onEvent, uploadedImage) {
     async (args) => {
       const tileUrl = `${SEARCH_URL}/tile/${args.article_id}/${args.tile_index}/${args.chunk_index}`
       try {
-        const resp = await fetch(tileUrl)
+        const resp = await fetch(tileUrl, { signal: AbortSignal.timeout(30000) })
         // The agent pages through articles by guessing chunk coordinates, so
         // 404s are normal exploration — only surface tiles that actually load,
         // otherwise the chat gallery renders broken images.
@@ -257,7 +258,7 @@ const server = http.createServer(async (req, res) => {
           systemPrompt: SYSTEM_PROMPT,
           mcpServers: { pixelrag: mcpServer },
           allowedTools: ["mcp__pixelrag__pixelrag_search", "mcp__pixelrag__pixelrag_tile"],
-          maxTurns: 20,
+          maxTurns: 8,
           maxBudgetUsd: MAX_BUDGET,
           maxThinkingTokens: THINKING_TOKENS,
           includePartialMessages: true,

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -7,7 +7,7 @@ import {
 import { z } from "zod"
 
 const SEARCH_URL =
-  process.env.PIXELRAG_SEARCH_URL || "http://localhost:30001"
+  process.env.PIXELRAG_SEARCH_URL || "https://api.pixelrag.ai"
 
 interface SearchHit {
   score: number
@@ -31,7 +31,7 @@ For every user question, without exception:
 2. Call pixelrag_tile to VIEW the screenshot tiles of the top results — this is how you read and compare. View at least 2-3 tiles.
 3. Answer from what the tiles show, and cite the Wikipedia URLs. If the tiles don't contain the answer, say so honestly.
 
-Be decisive and efficient: for open-ended or comparison questions, check a few strong candidates (about 3-5), then commit to your best answer from what you have seen — do not keep searching indefinitely.
+Be decisive and efficient: view at most 4 tiles total across 1-2 articles, then commit to your best answer. If tiles are too small or blurry to read, say so and answer from the article titles/URLs. Do NOT keep retrying with different tiles or fall back to web search/fetch — you only have pixelrag_search and pixelrag_tile. Stop after 2 tile attempts that yield no readable text.
 
 Never skip search and tile — including for visual or comparison questions; always look at Wikipedia tiles first, even when you think you already know the answer.
 
@@ -105,6 +105,7 @@ function createTools(
           n_docs: args.n_results ?? 5,
           articles_only: true,
         }),
+        signal: AbortSignal.timeout(30000),
       })
       if (!resp.ok) {
         return {
@@ -164,7 +165,7 @@ function createTools(
       const tileUrl = `${SEARCH_URL}/tile/${args.article_id}/${args.tile_index}/${args.chunk_index}`
 
       try {
-        const resp = await fetch(tileUrl)
+        const resp = await fetch(tileUrl, { signal: AbortSignal.timeout(30000) })
         // Only surface successfully fetched tiles — the agent pages through
         // articles by guessing chunk coordinates, so 404s are normal.
         if (resp.ok) {
@@ -315,7 +316,7 @@ export async function POST(req: Request) {
               "mcp__pixelrag__pixelrag_search",
               "mcp__pixelrag__pixelrag_tile",
             ],
-            maxTurns: 20,
+            maxTurns: 8,
             maxBudgetUsd: parseFloat(
               process.env.CHAT_MAX_BUDGET_USD || "0.50"
             ),

--- a/web/app/chat/page.tsx
+++ b/web/app/chat/page.tsx
@@ -24,6 +24,8 @@ import remarkGfm from "remark-gfm"
 import { Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { ModeToggle } from "@/components/ModeToggle"
+import { Lightbox } from "@/components/Lightbox"
+import type { Hit } from "@/lib/types"
 
 interface SearchResult {
   query: string
@@ -69,6 +71,8 @@ function ChatPageInner() {
   const [input, setInput] = React.useState("")
   const [image, setImage] = React.useState<string | undefined>()
   const [isStreaming, setIsStreaming] = React.useState(false)
+  const [lightboxHit, setLightboxHit] = React.useState<Hit | null>(null)
+  const [lightboxHits, setLightboxHits] = React.useState<Hit[]>([])
   const messagesEndRef = React.useRef<HTMLDivElement>(null)
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
   const fileInputRef = React.useRef<HTMLInputElement>(null)
@@ -116,8 +120,10 @@ function ChatPageInner() {
     const img = imageOverride ?? image
     if ((!query && !img) || isStreaming) return
     if (query) addHistory(query, "ask")
-    const userMsg: ChatMessage = { id: crypto.randomUUID(), role: "user", content: query, image: img }
-    const assistantMsg: ChatMessage = { id: crypto.randomUUID(), role: "assistant", content: "", searches: [] }
+    const id1 = crypto.randomUUID?.() ?? "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, c => { const r = Math.random() * 16 | 0; return (c === "x" ? r : (r & 0x3 | 0x8)).toString(16) })
+    const id2 = crypto.randomUUID?.() ?? "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, c => { const r = Math.random() * 16 | 0; return (c === "x" ? r : (r & 0x3 | 0x8)).toString(16) })
+    const userMsg: ChatMessage = { id: id1, role: "user", content: query, image: img }
+    const assistantMsg: ChatMessage = { id: id2, role: "assistant", content: "", searches: [] }
     setMessages((prev) => [...prev, userMsg, assistantMsg])
     setInput("")
     setImage(undefined)
@@ -183,6 +189,11 @@ function ChatPageInner() {
     setMessages([]); setIsStreaming(false); setInput(""); setImage(undefined); inputRef.current?.focus()
   }
 
+  function handleTileClick(hit: Hit, allHits: Hit[]) {
+    setLightboxHit(hit)
+    setLightboxHits(allHits)
+  }
+
   function handleFile(file: File) {
     if (!file.type.startsWith("image/")) return
     const reader = new FileReader()
@@ -215,7 +226,7 @@ function ChatPageInner() {
             <AnimatePresence initial={false}>
               {messages.map((msg) => (
                 <motion.div key={msg.id} initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.25 }}>
-                  {msg.role === "user" ? <UserMessage content={msg.content} image={msg.image} /> : <AssistantMessage message={msg} isStreaming={isStreaming && msg.id === messages[messages.length - 1]?.id} />}
+                  {msg.role === "user" ? <UserMessage content={msg.content} image={msg.image} /> : <AssistantMessage message={msg} isStreaming={isStreaming && msg.id === messages[messages.length - 1]?.id} onTileClick={handleTileClick} />}
                 </motion.div>
               ))}
             </AnimatePresence>
@@ -288,6 +299,17 @@ function ChatPageInner() {
           </div>
         </div>
       </div>
+
+      {/* Lightbox */}
+      {lightboxHit && (
+        <Lightbox
+          key={lightboxHit.vector_id}
+          hit={lightboxHit}
+          allHits={lightboxHits}
+          onClose={() => setLightboxHit(null)}
+          onNavigate={(hit) => setLightboxHit(hit)}
+        />
+      )}
     </div>
   )
 }
@@ -409,14 +431,14 @@ function UserMessage({ content, image }: { content: string; image?: string }) {
   )
 }
 
-function AssistantMessage({ message, isStreaming }: { message: ChatMessage; isStreaming: boolean }) {
+function AssistantMessage({ message, isStreaming, onTileClick }: { message: ChatMessage; isStreaming: boolean; onTileClick: (hit: Hit, allHits: Hit[]) => void }) {
   return (
     <div className="mb-8">
       {message.thinking && (
         <ThinkingTrace text={message.thinking} active={isStreaming && !message.content} />
       )}
-      {message.searches?.map((s, i) => <SearchCard key={i} result={s} />)}
-      {message.tiles && message.tiles.length > 0 && <TileGallery tiles={message.tiles} loading={message.viewingTile} />}
+      {message.searches?.map((s, i) => <SearchCard key={i} result={s} onTileClick={onTileClick} />)}
+      {message.tiles && message.tiles.length > 0 && <TileGallery tiles={message.tiles} loading={message.viewingTile} onTileClick={onTileClick} />}
 
       {message.searching && (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mb-4 flex items-center gap-2.5 rounded-lg border border-[var(--chat-border)] bg-[var(--chat-card)] px-3.5 py-2.5">
@@ -449,9 +471,20 @@ function AssistantMessage({ message, isStreaming }: { message: ChatMessage; isSt
 
 /* ─── Search Card ─── */
 
-function SearchCard({ result }: { result: SearchResult }) {
+function SearchCard({ result, onTileClick }: { result: SearchResult; onTileClick: (hit: Hit, allHits: Hit[]) => void }) {
   const [expanded, setExpanded] = React.useState(false)
   const shown = expanded ? result.hits : result.hits.slice(0, 5)
+  const hits = result.hits.map((h) => ({
+    score: h.score,
+    article_id: h.article_id,
+    tile_index: h.tile_index,
+    chunk_index: h.chunk_index,
+    url: h.url,
+    tile_height: h.tile_height,
+    vector_id: h.article_id * 10000 + h.tile_index * 100 + h.chunk_index,
+    y_offset: 0,
+    path: "",
+  } as Hit))
 
   return (
     <motion.div initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} className="mb-4 overflow-hidden rounded-xl border border-[var(--chat-border)] bg-[var(--chat-card)]">
@@ -464,9 +497,8 @@ function SearchCard({ result }: { result: SearchResult }) {
         {shown.map((hit, i) => {
           const slug = hit.url.includes("/wiki/") ? hit.url.split("/wiki/").pop() : hit.url
           const title = decodeURIComponent(slug || "").replace(/_/g, " ")
-          const fullUrl = hit.url.startsWith("http") ? hit.url : `https://en.wikipedia.org/wiki/${slug}`
           return (
-            <a key={i} href={fullUrl} target="_blank" rel="noopener noreferrer" className="group relative shrink-0 overflow-hidden rounded-lg transition-transform hover:scale-[1.02]">
+            <button key={i} onClick={() => onTileClick(hits[i], hits)} className="group relative shrink-0 overflow-hidden rounded-lg transition-transform hover:scale-[1.02]" title="Click to view full-size">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={tileUrl(hit)} alt={title} className="h-24 w-36 object-cover object-top" loading="lazy" />
               <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
@@ -474,7 +506,7 @@ function SearchCard({ result }: { result: SearchResult }) {
                 <span className="flex items-center gap-1 text-[10px] font-medium text-white"><span className="truncate">{title}</span><ExternalLink className="h-2.5 w-2.5 shrink-0 opacity-60" /></span>
               </div>
               <div className="absolute right-1 top-1 rounded bg-black/60 px-1 py-0.5 font-mono text-[8px] tabular-nums text-white/60 backdrop-blur-sm">{hit.score.toFixed(2)}</div>
-            </a>
+            </button>
           )
         })}
       </div>
@@ -564,7 +596,7 @@ const READING_VERBS = [
   "Scanning",
 ]
 
-function TileGallery({ tiles, loading }: { tiles: TileView[]; loading?: boolean }) {
+function TileGallery({ tiles, loading, onTileClick }: { tiles: TileView[]; loading?: boolean; onTileClick: (hit: Hit, allHits: Hit[]) => void }) {
   // Belt-and-braces: if a tile image 404s anyway, drop it from the gallery
   // instead of rendering a broken image.
   const [failed, setFailed] = React.useState<Set<string>>(new Set())
@@ -574,6 +606,23 @@ function TileGallery({ tiles, loading }: { tiles: TileView[]; loading?: boolean 
   // Seed by the first tile so the verb stays put as more tiles stream in,
   // but differs from answer to answer.
   const verb = READING_VERBS[(tiles[0]?.article_id ?? n) % READING_VERBS.length]
+
+  function tileToHit(t: TileView): Hit {
+    return {
+      score: 0,
+      article_id: t.article_id,
+      tile_index: t.tile_index,
+      chunk_index: t.chunk_index,
+      url: `https://en.wikipedia.org/?curid=${t.article_id}`,
+      tile_height: 0,
+      vector_id: t.article_id * 10000 + t.tile_index * 100 + t.chunk_index,
+      y_offset: 0,
+      path: "",
+    }
+  }
+
+  const hits = shown.map(tileToHit)
+
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mb-5">
       <div className="mb-2.5 flex items-center gap-2">
@@ -585,10 +634,10 @@ function TileGallery({ tiles, loading }: { tiles: TileView[]; loading?: boolean 
       </div>
       <div className="flex gap-2.5 overflow-x-auto pb-1 scrollbar-thin">
         {shown.map((t, i) => (
-          <motion.a key={i} href={tileUrl(t)} target="_blank" rel="noopener noreferrer"
-            title="Open full-size tile (right-click to copy or save)"
+          <motion.button key={i} onClick={() => onTileClick(hits[i], hits)}
+            title="Click to view full-size"
             initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} transition={{ delay: i * 0.08 }}
-            className="group/tile relative block shrink-0 overflow-hidden rounded-xl border-2 border-[var(--chat-warm)] border-opacity-20 shadow-lg shadow-[var(--chat-warm)]/5">
+            className="group/tile relative block shrink-0 overflow-hidden rounded-xl border-2 border-[var(--chat-warm)] border-opacity-20 shadow-lg shadow-[var(--chat-warm)]/5 text-left">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src={tileUrl(t)} alt={`Tile ${t.article_id}/${t.tile_index}/${t.chunk_index}`} className="h-48 w-80 object-cover object-top transition-transform duration-300 group-hover/tile:scale-[1.02]" loading="lazy" onError={() => setFailed((prev) => new Set(prev).add(key(t)))} />
             <div className="pointer-events-none absolute right-2 top-2 flex items-center gap-1 rounded-md bg-black/55 px-2 py-1 text-[10px] font-medium text-white opacity-0 backdrop-blur-sm transition-opacity group-hover/tile:opacity-100">
@@ -598,7 +647,7 @@ function TileGallery({ tiles, loading }: { tiles: TileView[]; loading?: boolean 
               <span className="relative flex h-1.5 w-1.5"><span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--chat-warm)] opacity-40" /><span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-[var(--chat-warm)]" /></span>
               <span className="font-mono text-[10px] tabular-nums text-[var(--chat-muted)]">{t.article_id}:{t.tile_index}:{t.chunk_index}</span>
             </div>
-          </motion.a>
+          </motion.button>
         ))}
       </div>
     </motion.div>

--- a/web/components/Lightbox.tsx
+++ b/web/components/Lightbox.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { motion, AnimatePresence } from "framer-motion"
-import { ChevronLeft, ChevronRight, X, ExternalLink } from "lucide-react"
+import { ChevronLeft, ChevronRight, X, ExternalLink, ArrowLeft } from "lucide-react"
 import { tileUrl } from "@/lib/api"
 import type { Hit } from "@/lib/types"
 import { Button } from "@/components/ui/button"
@@ -111,17 +111,34 @@ export function Lightbox({ hit, allHits, onClose, onNavigate }: LightboxProps) {
           onClick={(e) => e.stopPropagation()}
         >
           {/* Image area */}
-          <div
-            ref={imageAreaRef}
-            className="flex flex-1 items-center justify-center overflow-hidden"
-            onMouseDown={handleMouseDown}
-            onMouseMove={handleMouseMove}
-            onMouseUp={handleMouseUp}
-            onMouseLeave={handleMouseUp}
-            style={{ cursor: isDragging ? "grabbing" : "grab" }}
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+          <div className="relative flex flex-1 flex-col">
+            {/* Back button bar — prominent, always visible */}
+            <div className="absolute left-0 right-0 top-0 z-20 flex items-center justify-between px-4 py-3" style={{ background: "linear-gradient(to bottom, rgba(0,0,0,0.55) 0%, transparent 100%)" }}>
+              <button
+                onClick={onClose}
+                className="flex items-center gap-2 rounded-lg bg-white/10 px-3 py-1.5 text-sm font-medium text-white backdrop-blur-sm transition-colors hover:bg-white/20"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back
+              </button>
+              <button
+                onClick={onClose}
+                className="rounded-lg p-1.5 text-white/70 backdrop-blur-sm transition-colors hover:bg-white/10 hover:text-white"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <div
+              ref={imageAreaRef}
+              className="flex flex-1 items-center justify-center overflow-hidden"
+              onMouseDown={handleMouseDown}
+              onMouseMove={handleMouseMove}
+              onMouseUp={handleMouseUp}
+              onMouseLeave={handleMouseUp}
+              style={{ cursor: isDragging ? "grabbing" : "grab" }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
               src={tileUrl(hit)}
               alt={`Tile ${hit.tile_index}`}
               className="max-h-[90vh] max-w-full select-none"
@@ -130,6 +147,7 @@ export function Lightbox({ hit, allHits, onClose, onNavigate }: LightboxProps) {
                 transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
               }}
             />
+          </div>
           </div>
 
           {/* Metadata sidebar */}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -18,7 +18,7 @@ const nextConfig: NextConfig = {
     // take precedence over this rewrite. Uses the public host so it works on
     // Vercel (localhost only exists in local dev).
     const searchBackend =
-      process.env.PIXELRAG_SEARCH_PROXY || "http://api.pixelrag.ai:30001";
+      process.env.PIXELRAG_SEARCH_PROXY || "https://api.pixelrag.ai";
     return [
       {
         source: "/api/:path*",


### PR DESCRIPTION
## Summary
- Add 30s fetch timeouts to search and tile API calls to prevent hanging on slow networks
- Change default `SEARCH_URL` from `http://api.pixelrag.ai:30001` to `https://api.pixelrag.ai` (standard HTTPS port is less likely to be blocked by firewalls)
- Reduce `maxTurns` from 20 to 8 to prevent agent retry loops when tiles are unreadable
- Update system prompt to cap tile views at 4 and explicitly forbid web search/fetch fallback
- Add Lightbox component to chat page so clicking SearchCard or TileGallery tiles opens a proper image viewer instead of navigating to raw tile URLs
- Add prominent "Back" button bar to the Lightbox overlay (previously only a subtle X in the sidebar)
- Fix `crypto.randomUUID()` crash when accessing via non-localhost origins (e.g. LAN IP)

## Test plan
- [x] Search page: click result tile → Lightbox with Back button
- [x] Chat page: click SearchCard tile → Lightbox with Back button  
- [x] Chat page: click TileGallery tile → Lightbox with Back button
- [x] TypeScript type check passes
- [x] API fetch timeouts set to 30s for both search and tile endpoints

## Note
These fixes were discovered while deploying locally. The port 30001 default was unreachable from certain network environments; the HTTPS port 443 works reliably.