### PR TITLE
docs: move Data Curation section to train/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,13 +239,6 @@ We also release the full training set
 ([`Chrisyichuan/screenshot-training-natural-filtered-v2`](https://huggingface.co/datasets/Chrisyichuan/screenshot-training-natural-filtered-v2)),
 so you can adapt other backbones yourself — a larger Qwen, or any other embedding model.
 
-### Data Curation
-
-Visualization of some very early version of the training data:
-[early training data viewer](https://yichuan-w.github.io/share/blog-review-first100-light/)
-
-Reproduce: TBD
-
 ## Acknowledgments
 
 Thanks to [Rulin Shao](https://rulinshao.github.io/) for support.

--- a/train/README.md
+++ b/train/README.md
@@ -402,3 +402,10 @@ one launch command per run, each adding a single knob. Results are summarized in
 
 For maintainer notes on training internals, hard-negative filtering, dataset
 packaging, and tests, see [`docs/training_dev_notes.md`](./docs/training_dev_notes.md).
+
+## Data Curation
+
+Visualization of some very early version of the training data:
+[early training data viewer](https://yichuan-w.github.io/share/blog-review-first100-light/)
+
+Reproduce: TBD


### PR DESCRIPTION
## Summary
- Moved the Data Curation section (early training data viewer link + reproduce TBD) from the root README to `train/README.md` where it belongs alongside the rest of the training docs.