### PR TITLE
fix(render): isolate Chrome --user-data-dir per worker (fixes #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,13 @@ pixelshot paper.pdf -o ./tiles --dpi 200
 pixelshot https://github.com/StarTrail-org/PixelRAG paper.pdf -o ./tiles
 ```
 
+> **Chrome on Windows/macOS** — the bundled turbo `headless_shell` auto-installs on
+> **linux-x64** only. Elsewhere, `pixelshot` uses your system Chrome/Chromium (or
+> Playwright's Chromium), auto-detected from the standard install locations. Point it at
+> a specific binary with `CHROME_PATH=/path/to/chrome` if it isn't found automatically.
+> Each render runs in an isolated, throwaway Chrome profile, so it works even while you
+> have Chrome open.
+
 ### Embed tools (standalone)
 
 Each stage runs independently, without the orchestrator:

--- a/render/src/pixelrag_render/backends/cdp.py
+++ b/render/src/pixelrag_render/backends/cdp.py
@@ -24,8 +24,10 @@ import base64
 import io
 import json
 import logging
+import shutil
 import signal
 import subprocess
+import tempfile
 import time
 import urllib.request
 from pathlib import Path
@@ -314,11 +316,21 @@ async def _worker(
     results: list,
 ):
     """Async worker: owns a Chrome process, pulls URLs from queue."""
+    # Isolated profile per worker. Without --user-data-dir, a launch on a machine that
+    # already has Chrome open forwards to the running instance (default profile) instead
+    # of starting this headless renderer — navigation/screenshot then hang forever. A
+    # unique dir also stops parallel workers from colliding on one profile. See issue #54.
+    user_data_dir = tempfile.mkdtemp(prefix=f"pixelshot_chrome_{port}_")
     proc = subprocess.Popen(
         # `--headless=new`: the bare `--headless` is deprecated and hangs on modern
         # Chrome (e.g. google-chrome 149); `=new` works on both stock Chrome and the
         # patched headless_shell.
-        [chrome_path, f"--remote-debugging-port={port}", "--headless=new"]
+        [
+            chrome_path,
+            f"--remote-debugging-port={port}",
+            "--headless=new",
+            f"--user-data-dir={user_data_dir}",
+        ]
         + BROWSER_ARGS
         + ["about:blank"],
         stdout=subprocess.DEVNULL,
@@ -388,6 +400,7 @@ async def _worker(
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
+        shutil.rmtree(user_data_dir, ignore_errors=True)
 
 
 def _derive_stems(urls: list[str], stems: list[str] | None) -> list[str]:

--- a/render/src/pixelrag_render/backends/fast_cdp.py
+++ b/render/src/pixelrag_render/backends/fast_cdp.py
@@ -25,9 +25,11 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import signal
 import struct
 import subprocess
+import tempfile
 import time
 import urllib.request
 from pathlib import Path
@@ -115,12 +117,22 @@ def _next_base_port() -> int:
 
 
 async def _launch_chrome(chrome_path: str, port: int) -> tuple:
-    """Launch a headless Chrome and return (websocket, proc)."""
+    """Launch a headless Chrome and return (websocket, proc, user_data_dir)."""
     import websockets
 
+    # Isolated profile per worker. Without --user-data-dir, a launch on a machine that
+    # already has Chrome open forwards to the running instance (default profile) instead
+    # of starting this headless renderer — navigation/screenshot then hang forever. A
+    # unique dir also stops parallel workers from colliding on one profile. See issue #54.
+    user_data_dir = tempfile.mkdtemp(prefix=f"pixelshot_chrome_{port}_")
     args = (
         # `--headless=new`: bare `--headless` is deprecated and hangs on modern Chrome.
-        [chrome_path, f"--remote-debugging-port={port}", "--headless=new"]
+        [
+            chrome_path,
+            f"--remote-debugging-port={port}",
+            "--headless=new",
+            f"--user-data-dir={user_data_dir}",
+        ]
         + CHROME_ARGS
         + ["about:blank"]
     )
@@ -142,19 +154,21 @@ async def _launch_chrome(chrome_path: str, port: int) -> tuple:
                 open_timeout=10,
                 max_size=50 * 1024 * 1024,
             )
-            return ws, proc
+            return ws, proc, user_data_dir
         except Exception:
             if attempt == 9:
                 proc.kill()
+                shutil.rmtree(user_data_dir, ignore_errors=True)
                 raise ConnectionError(f"Failed to connect to Chrome on port {port}")
 
 
 class _Conn:
     """Minimal CDP connection with a receive loop."""
 
-    def __init__(self, ws, proc):
+    def __init__(self, ws, proc, user_data_dir=None):
         self._ws = ws
         self._proc = proc
+        self._user_data_dir = user_data_dir
         self._msg_id = 0
         self._pending: dict[int, asyncio.Future] = {}
         self._event_listeners: dict[str, list] = {}
@@ -238,6 +252,8 @@ class _Conn:
             self._proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             self._proc.kill()
+        if self._user_data_dir:
+            shutil.rmtree(self._user_data_dir, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------
@@ -328,8 +344,8 @@ async def _run_render(
         base_port + n_workers - 1,
     )
     for i in range(n_workers):
-        ws, proc = await _launch_chrome(chrome_path, base_port + i)
-        conn = _Conn(ws, proc)
+        ws, proc, user_data_dir = await _launch_chrome(chrome_path, base_port + i)
+        conn = _Conn(ws, proc, user_data_dir)
         connections.append(conn)
 
     for i, conn in enumerate(connections):


### PR DESCRIPTION
## Problem

`pixelshot` hangs and fails on Windows/macOS when the configured Chrome is a normal
system install and the user **already has Chrome open** (the common desktop case). Every
URL fails with `done=0 failed=1` after a ~180s hang (an `asyncio.TimeoutError` on
`ws.recv()`):

```
WARNING pixelrag_render.backends.cdp: [w0] FAIL https://example.com:
INFO    pixelrag_render.backends.cdp: Batch complete: done=0 failed=1
```

This is the **second of the two root causes** described in #54. The first — `_connect_cdp`
selecting a non-page CDP target — was already fixed in #56. This PR fixes the second.

## Root cause

Both CDP backends launch Chrome with `--remote-debugging-port` but **no `--user-data-dir`**:

- `render/src/pixelrag_render/backends/cdp.py` — `_worker` (standard path)
- `render/src/pixelrag_render/backends/fast_cdp.py` — `_launch_chrome` (turbo path)

Without an explicit profile dir, a new `chrome --remote-debugging-port=…` invocation
**forwards to an already-running Chrome instance** on the default profile instead of
starting its own headless renderer. The CDP endpoint comes up and trivial
`Runtime.evaluate` works, but `Page.navigate` never commits and `Page.captureScreenshot`
hangs forever.

It's masked on Linux/CI because the bundled `headless_shell` launches fresh with no
competing instance, so the default profile is never contended.

## Fix

Give each worker an isolated, throwaway profile via `tempfile.mkdtemp`, pass it as
`--user-data-dir`, and remove it on teardown (including the connect-failure path in the
turbo backend). A unique profile per worker also prevents parallel workers from colliding
on a single profile.

Also documents cross-platform Chrome resolution in the README: the bundled turbo
`headless_shell` auto-installs on **linux-x64** only; Windows/macOS use auto-detected
system Chrome/Chromium (or `CHROME_PATH`).

## Verification

On **Windows 11** with system **Chrome 149** (`CHROME_PATH` set):

- Before: `pixelshot https://example.com` → `done=0 failed=1` after ~180s.
- After: `done=1 failed=0`, valid `tile_0000.jpg` produced; temp profile dirs are created
  per worker and cleaned up afterward (no leftovers under the temp dir).
- `ruff check` / `ruff format --check`: clean.
- Existing render + chrome tests pass (`tests/test_render.py`, `tests/test_chrome_paths.py`).

## Risk

Low. Adding `--user-data-dir` is a no-op on a freshly-launched Chrome (Linux/CI) and is
the standard way to isolate Chrome instances; it only changes behavior in exactly the
contended-profile case the bug describes. Teardown uses `rmtree(..., ignore_errors=True)`
so a still-locked profile dir never raises.

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
