### PR TITLE
fix: handle non-numeric filename-stem IDs in local source pipeline

### DIFF
--- a/index/src/pixelrag_index/pipelines.py
+++ b/index/src/pixelrag_index/pipelines.py
@@ -98,17 +98,22 @@ def build(config: dict, limit: int | None = None, force: bool = False) -> Path:
     if pdf_docs:
         logger.info("  Rendered %d PDFs", len(pdf_docs))
 
-    # Save articles.json for serve API — title + URL per article
+    # Save articles.json for serve API — title + URL per article.
+    # Use the pipeline's sequential *position index* (0, 1, 2, …) rather than
+    # int(a["id"]), because local sources use filename stems (e.g. "art_alice")
+    # as doc IDs, which are not numeric. int() on a filename stem raises ValueError
+    # and crashes the entire index build step.
     articles_path = output / "articles.json"
-    max_idx = max(int(a["id"]) for a in articles) + 1 if articles else 0
-    article_entries = [{"title": "", "url": ""}] * max_idx
-    for a in articles:
-        idx = int(a["id"])
+    article_entries = []
+    for enum_idx, a in enumerate(articles):
         title = a.get("metadata", {}).get("title", "")
         if not title and a.get("url"):
             title = a["url"].split("/")[-1].replace("_", " ").replace("%20", " ")
-        url = a.get("url", "")
-        article_entries[idx] = {"title": title or str(idx), "url": url}
+        if not title:
+            # Fall back to original doc id (e.g. filename stem) as display title
+            title = a.get("id", str(enum_idx))
+        url = a.get("url", "") or a.get("path", "")
+        article_entries.append({"title": title, "url": url})
     with open(articles_path, "w") as f:
         json.dump(article_entries, f)
     logger.info(

--- a/tests/repro_bug1.py
+++ b/tests/repro_bug1.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+repro_bug1.py — Minimal reproduction of the int() crash on non-numeric local IDs.
+
+Reproduce WITHOUT needing a full PixelRAG installation:
+    python repro_bug1.py
+
+Expected on upstream v0.2.1 (before fix):
+    ValueError: invalid literal for int() with base 10: 'my_photo'
+
+Expected after fix:
+    PASS — article_entries has 2 entries with display titles.
+"""
+
+# Simulate the upstream article list from the pipeline (strings from filename stems)
+articles = [
+    {"id": "my_photo",        "url": "",  "path": "/tmp/my_photo.jpg",  "metadata": {}},
+    {"id": "chart_btcusdt",   "url": "",  "path": "/tmp/chart.png",     "metadata": {}},
+]
+
+print("Testing upstream behavior (BEFORE fix):")
+print("=" * 50)
+try:
+    max_idx = max(int(a["id"]) for a in articles) + 1 if articles else 0
+    print(f"  max_idx = {max_idx}")
+    article_entries = [{"title": "", "url": ""}] * max_idx
+    for a in articles:
+        idx = int(a["id"])            # <-- crashes here on non-numeric IDs
+        article_entries[idx] = {"title": str(idx), "url": a.get("url", "")}
+    print("  PASS (unexpected — upstream has numeric IDs in this path)")
+except ValueError as e:
+    print(f"  FAIL (expected on upstream): {e}")
+
+print()
+print("Testing FIXED behavior (enumerate-based):")
+print("=" * 50)
+article_entries = []
+for enum_idx, a in enumerate(articles):
+    title = a.get("metadata", {}).get("title", "")
+    if not title and a.get("url"):
+        title = a["url"].split("/")[-1]
+    if not title:
+        title = a.get("id", str(enum_idx))     # filename stem as fallback title
+    url = a.get("url", "") or a.get("path", "")
+    article_entries.append({"title": title, "url": url})
+
+for i, entry in enumerate(article_entries):
+    print(f"  [{i}] title={entry['title']!r:20s}  url={entry['url']!r}")
+
+assert len(article_entries) == 2
+assert article_entries[0]["title"] == "my_photo"
+assert article_entries[1]["title"] == "chart_btcusdt"
+print()
+print("PASS — all assertions OK")


### PR DESCRIPTION
### What breaks

When using `--source-type local` with images that have non-numeric filename stems (e.g. `photo.jpg`, `btc_chart.png`), the index build crashes at Stage 1 with:

```
ValueError: invalid literal for int() with base 10: 'btc_chart'
```

Root cause: `pipelines.py` builds `articles.json` using `int(a["id"])` to index into a pre-allocated list. For local image sources, `doc.id` is the filename stem (a string), not an integer. This works fine for Wikipedia-style URL sources where IDs are numeric, but fails for any local image file with a non-numeric name.

### Reproduction

```bash
mkdir /tmp/demo_corpus
cp my_image.jpg /tmp/demo_corpus/my_photo.jpg
pixelrag index build --source-type local --source /tmp/demo_corpus --output /tmp/test_idx
# → ValueError: invalid literal for int() with base 10: 'my_photo'
```

A self-contained reproduction script (no PixelRAG install needed) is at `tests/repro_bug1.py` in this branch.

### Fix

Replace the `int(a["id"])` position-index pattern with `enumerate(articles)`. The pipeline already assigns sequential positions (`idx = len(articles)`) at article collection time; `articles.json` is consumed positionally by the serve layer. Using enumerate keeps the positional contract while accepting any string ID.

As a bonus, the fallback title now uses the original doc ID (e.g. the filename stem) instead of an empty string, so local images show a human-readable label in the UI.

### Impact

- No change to URL or PDF source behaviour (they still get sequential indices).
- `articles.json` output format is unchanged (list of `{title, url}` objects).
- No migration needed for existing indexes built from URL/PDF sources.

### Tests

The upstream test suite does not yet cover `pipelines.build()` directly. The `tests/repro_bug1.py` script in this branch verifies both the broken and fixed path with a standalone assertion. Adding a proper pytest fixture for `pipelines.py` is tracked separately; this PR keeps the fix minimal and reviewable.

### Checklist
- [x] Bug reproduced on v0.2.1
- [x] Fix verified locally with non-numeric filename stems
- [x] No regression on URL source path (logic unchanged for `url_docs`)
- [x] `articles.json` output format unchanged
