### PR TITLE
chore(uptime): write monitoring data to a dedicated `status` branch, not main

### DIFF
--- a/.github/workflows/uptime-response-time.yml
+++ b/.github/workflows/uptime-response-time.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.head_ref }}
+          ref: status
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
         uses: upptime/uptime-monitor@v1.41.8

--- a/.github/workflows/uptime-summary.yml
+++ b/.github/workflows/uptime-summary.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.head_ref }}
+          ref: status
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary
         uses: upptime/uptime-monitor@v1.41.8

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.head_ref }}
+          ref: status
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
         uses: upptime/uptime-monitor@v1.41.8

--- a/status-site/index.html
+++ b/status-site/index.html
@@ -149,7 +149,7 @@
 </main>
 
 <script>
-const SUMMARY_URL = "https://raw.githubusercontent.com/StarTrail-org/PixelRAG/main/history/summary.json";
+const SUMMARY_URL = "https://raw.githubusercontent.com/StarTrail-org/PixelRAG/status/history/summary.json";
 const DAYS = 90;
 
 function fmtTime(ms) {


### PR DESCRIPTION
## Why

The Upptime monitors (**Summary CI** etc.) commit `history/` + `summary.json` to **main** every few minutes. main is branch-protected ("changes must be made through a pull request"), so each scheduled run fails:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] main -> main (push declined)
```

Even if it succeeded, it would bury main's history under hundreds of bot commits a day. Monitoring data is generated operational state, not source — it shouldn't live on the protected source branch or require a bypass token.

## What

- Point the 3 data-writing workflows (`uptime.yml`, `uptime-summary.yml`, `uptime-response-time.yml`) at a dedicated unprotected **`status`** branch (`ref: status`). The default `GITHUB_TOKEN` can push there; no PAT / no branch-protection bypass needed.
- Read the static status page's `summary.json` from the `status` branch.
- `status-site.yml` (gh-pages deploy) unchanged.

The `status` branch has been created from main. After merge, the next scheduled run writes there and the red CI on main clears.

**Follow-up:** the now-stale `history/` on main can be removed in a later cleanup.