### PR TITLE
fix(chrome): sort Playwright Chromium by revision, not lexically

### DIFF
--- a/render/src/pixelrag_render/chrome.py
+++ b/render/src/pixelrag_render/chrome.py
@@ -16,6 +16,7 @@ Programmatic:
 import json
 import os
 import platform
+import re
 import subprocess
 import sys
 import tarfile
@@ -32,6 +33,17 @@ RELEASE_URL_TEMPLATE = (
     "https://github.com/StarTrail-org/PixelRAG/releases/download/"
     "chrome-{version}/headless_shell-linux-x64.tar.zst"
 )
+
+
+def _playwright_revision(path: str) -> int:
+    """Integer Playwright Chromium revision embedded in ``path``.
+
+    Playwright caches browsers under ``chromium-<revision>`` with a plain
+    monotonically-increasing integer revision. Paths without a recognizable
+    revision sort last (``-1``) rather than raising.
+    """
+    m = re.search(r"chromium-(\d+)", path)
+    return int(m.group(1)) if m else -1
 
 
 def _candidate_chrome_paths(system: str | None = None) -> list[str]:
@@ -55,8 +67,11 @@ def _candidate_chrome_paths(system: str | None = None) -> list[str]:
     paths.append(str(INSTALL_DIR / "headless_shell"))
 
     def add_playwright(cache_dir: Path, rel_glob: str) -> None:
-        # Newest chromium-NNNN first.
-        paths.extend(sorted(glob.glob(str(cache_dir / rel_glob)), reverse=True))
+        # Newest chromium-NNNN first. Sort by integer revision, not lexically:
+        # a string sort ranks "chromium-999" above "chromium-1187" once the
+        # revision crosses the 3→4 digit boundary, picking an older browser.
+        matches = glob.glob(str(cache_dir / rel_glob))
+        paths.extend(sorted(matches, key=_playwright_revision, reverse=True))
 
     if system == "Darwin":
         add_playwright(

--- a/tests/test_chrome_paths.py
+++ b/tests/test_chrome_paths.py
@@ -31,3 +31,30 @@ def test_find_chrome_returns_executable():
     # On any supported dev box this resolves to an installed/usable binary.
     path = find_chrome()
     assert os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def test_playwright_chromium_sorted_by_revision_not_lexically(monkeypatch):
+    """Newer Playwright Chromium revisions must rank ahead of older ones.
+
+    Playwright caches browsers under ``chromium-<revision>`` with a plain
+    integer revision. A lexicographic sort ranks ``chromium-999`` above
+    ``chromium-1187`` once revisions cross the 3→4 digit boundary, so the
+    resolver would pick an *older* browser. Sorting by integer revision fixes
+    that — assert the candidate list is newest-first regardless of digit count.
+    """
+    import glob
+
+    found = [
+        "/home/u/.cache/ms-playwright/chromium-999/chrome-linux/chrome",
+        "/home/u/.cache/ms-playwright/chromium-1208/chrome-linux/chrome",
+        "/home/u/.cache/ms-playwright/chromium-1187/chrome-linux/chrome",
+    ]
+    monkeypatch.setattr(glob, "glob", lambda pattern: list(found))
+
+    paths = _candidate_chrome_paths("Linux")
+    revisions = [p for p in paths if "ms-playwright" in p]
+    assert revisions == [
+        "/home/u/.cache/ms-playwright/chromium-1208/chrome-linux/chrome",
+        "/home/u/.cache/ms-playwright/chromium-1187/chrome-linux/chrome",
+        "/home/u/.cache/ms-playwright/chromium-999/chrome-linux/chrome",
+    ]


### PR DESCRIPTION
## What

`_candidate_chrome_paths` sorts Playwright's `chromium-*` browser
directories lexicographically:

```python
paths.extend(sorted(glob.glob(str(cache_dir / rel_glob)), reverse=True))
```

The comment promises *"Newest chromium-NNNN first,"* but a string sort
breaks that contract once the revision crosses the 3→4 digit boundary:
`"chromium-999"` ranks **above** `"chromium-1187"`. Since `find_chrome()`
returns the first valid match, the resolver then silently selects an
**older** Chromium than the one the user just installed.

This triggers whenever two or more Playwright Chromium revisions are
cached and straddle that boundary — a normal state after `playwright
install` upgrades, which leave older revisions in place.

## Fix

Sort by the integer revision parsed from `chromium-<n>` instead of by
string. Paths without a recognizable revision sort last (`-1`) rather
than raising.

## Test

Adds `test_playwright_chromium_sorted_by_revision_not_lexically`, which
feeds `chromium-999`, `chromium-1187`, `chromium-1208` and asserts the
candidate list is newest-first. It fails on the old lexicographic sort
(`chromium-999` landed first) and passes with this change. The existing
chrome-path tests are unaffected (`6 passed`).
