### PR TITLE
feat(index): default to --wait-network-idle for URL rendering

### DIFF
--- a/index/src/pixelrag_index/pipelines.py
+++ b/index/src/pixelrag_index/pipelines.py
@@ -28,6 +28,10 @@ def build(config: dict, limit: int | None = None, force: bool = False) -> Path:
     tiles_dir = output / "tiles"
     embeddings_dir = output / "embeddings"
     ingest_cfg = config.get("ingest", {})
+    # Default to waiting for network idle — most modern pages are JS-rendered
+    # SPAs that produce blank/incomplete tiles without this. Users can opt out
+    # with `ingest: {wait_network_idle: false}` in their pixelrag.yaml.
+    ingest_cfg.setdefault("wait_network_idle", True)
     embed_cfg = config.get("embed", {})
     device = embed_cfg.get("device", "cpu")
 


### PR DESCRIPTION
Addresses #89.

## Problem

The `pixelbrowse` skill already uses `--wait-network-idle` (the skill docs even say "Always use it"), but `pixelrag index build` did not enable it by default. Users building indexes of JS-rendered sites (React, Next.js, SPAs) got blank or incomplete tiles silently.

## Fix

One line: `ingest_cfg.setdefault("wait_network_idle", True)` in `pipelines.py`.

Users can opt out with:
```yaml
ingest:
  wait_network_idle: false
```

## Why this is safe
- SSR pages (Wikipedia, docs) fire `load` immediately — the idle wait adds <500ms
- The CDP backend already has a hard timeout (12s) so it never hangs
- The pixelbrowse skill has used this as default since day one with no issues