### PR TITLE
feat(index): validate pixelrag.yaml on load — catch typos early

### DIFF
--- a/index/src/pixelrag_index/config.py
+++ b/index/src/pixelrag_index/config.py
@@ -1,17 +1,81 @@
-"""Parse pixelrag.yaml with parameter forwarding."""
+"""Parse pixelrag.yaml with parameter forwarding and validation."""
 
+import logging
 import os
+from difflib import get_close_matches
 from pathlib import Path
 
 import yaml
 
 from .sources import SOURCES
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_CONFIG = {
     "ingest": {"backend": "cdp", "quality": 85, "tile_height": 8192},
     "embed": {"model": "Qwen/Qwen3-VL-Embedding-2B", "device": "cuda"},
     "output": "./index",
 }
+
+# Valid values for validated fields
+_VALID = {
+    "source.type": list(SOURCES.keys()),
+    "embed.device": ["auto", "cpu", "cuda", "mps"],
+    "ingest.backend": ["cdp", "playwright"],
+}
+
+# Known keys per section (for typo detection)
+_KNOWN_KEYS = {
+    "source": {"type", "path", "urls_file", "zim_path", "preset"},
+    "embed": {"model", "device", "gpu_ids", "backend", "instruction", "batch_size"},
+    "ingest": {"backend", "quality", "tile_height", "wait_network_idle", "viewport_width", "workers"},
+}
+
+_KNOWN_TOP_LEVEL = {"source", "embed", "ingest", "output"}
+
+
+class ConfigValidationError(ValueError):
+    """Raised when pixelrag.yaml has invalid values."""
+    pass
+
+
+def _validate(config: dict) -> list[str]:
+    """Validate config and return list of warnings. Raises on hard errors."""
+    warnings = []
+
+    # Check unknown top-level keys
+    for key in config:
+        if key not in _KNOWN_TOP_LEVEL:
+            suggestion = get_close_matches(key, _KNOWN_TOP_LEVEL, n=1, cutoff=0.6)
+            hint = f" Did you mean '{suggestion[0]}'?" if suggestion else ""
+            warnings.append(f"Unknown top-level key '{key}'.{hint}")
+
+    # Check unknown keys within sections
+    for section, known in _KNOWN_KEYS.items():
+        section_data = config.get(section, {})
+        if not isinstance(section_data, dict):
+            continue
+        for key in section_data:
+            if key not in known:
+                suggestion = get_close_matches(key, known, n=1, cutoff=0.6)
+                hint = f" Did you mean '{suggestion[0]}'?" if suggestion else ""
+                warnings.append(f"Unknown key '{key}' in '{section}' config.{hint}")
+
+    # Validate constrained values
+    for field_path, valid_values in _VALID.items():
+        section, key = field_path.split(".")
+        value = config.get(section, {}).get(key) if isinstance(config.get(section), dict) else None
+        if value is not None and value not in valid_values:
+            raise ConfigValidationError(
+                f"Invalid {field_path}='{value}'. Must be one of: {valid_values}"
+            )
+
+    # Source must have type
+    source = config.get("source", {})
+    if isinstance(source, dict) and "type" not in source:
+        warnings.append("'source.type' not specified, defaulting to 'local'.")
+
+    return warnings
 
 
 def load_config(path=None):
@@ -25,6 +89,12 @@ def load_config(path=None):
             config = yaml.safe_load(f) or {}
     else:
         config = {}
+
+    # Validate
+    warnings = _validate(config)
+    for w in warnings:
+        logger.warning("pixelrag.yaml: %s", w)
+
     return {**DEFAULT_CONFIG, **config}
 
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,80 @@
+"""Tests for pixelrag.yaml config validation (issue #98)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "index" / "src"))
+from pixelrag_index.config import ConfigValidationError, _validate, load_config
+
+
+def test_valid_config_no_warnings():
+    config = {
+        "source": {"type": "local", "path": "./docs"},
+        "embed": {"device": "auto"},
+        "ingest": {"backend": "cdp"},
+        "output": "./index",
+    }
+    warnings = _validate(config)
+    assert warnings == []
+
+
+def test_invalid_device_raises():
+    config = {"embed": {"device": "tpu"}}
+    with pytest.raises(ConfigValidationError, match="device.*tpu"):
+        _validate(config)
+
+
+def test_invalid_source_type_raises():
+    config = {"source": {"type": "s3"}}
+    with pytest.raises(ConfigValidationError, match="source.type.*s3"):
+        _validate(config)
+
+
+def test_invalid_backend_raises():
+    config = {"ingest": {"backend": "selenium"}}
+    with pytest.raises(ConfigValidationError, match="backend.*selenium"):
+        _validate(config)
+
+
+def test_typo_in_top_level_key_warns():
+    config = {"souce": {"type": "local"}}  # typo: souce → source
+    warnings = _validate(config)
+    assert any("souce" in w for w in warnings)
+    assert any("source" in w for w in warnings)  # suggests correction
+
+
+def test_typo_in_section_key_warns():
+    config = {"embed": {"devie": "auto"}}  # typo: devie → device
+    warnings = _validate(config)
+    assert any("devie" in w for w in warnings)
+    assert any("device" in w for w in warnings)
+
+
+def test_missing_source_type_warns():
+    config = {"source": {"path": "./docs"}}
+    warnings = _validate(config)
+    assert any("source.type" in w for w in warnings)
+
+
+def test_valid_values_pass():
+    """All valid device/source/backend values should not raise."""
+    for device in ["auto", "cpu", "cuda", "mps"]:
+        _validate({"embed": {"device": device}})
+    for stype in ["local", "web", "pdf", "kiwix"]:
+        _validate({"source": {"type": stype}})
+    for backend in ["cdp", "playwright"]:
+        _validate({"ingest": {"backend": backend}})
+
+
+def test_load_config_with_typo_warns(tmp_path, caplog):
+    import logging
+
+    config_path = tmp_path / "pixelrag.yaml"
+    config_path.write_text("embed:\n  devie: auto\n")
+
+    with caplog.at_level(logging.WARNING):
+        load_config(str(config_path))
+
+    assert any("devie" in r.message for r in caplog.records)


### PR DESCRIPTION
Fixes #98.

## Problem

Typos in `pixelrag.yaml` (e.g., `devie: auto`) silently fall through to defaults. Users get unexpected behavior with no error.

## Fix

Adds validation in `config.py` that:
- **Raises** on invalid values: `source.type`, `embed.device`, `ingest.backend` must be from a known set
- **Warns** on unknown keys with "Did you mean X?" suggestions (difflib fuzzy matching)
- **Warns** when `source.type` is missing

## Example output

```
WARNING pixelrag.yaml: Unknown key 'devie' in 'embed' config. Did you mean 'device'?
```

```
ConfigValidationError: Invalid embed.device='tpu'. Must be one of: ['auto', 'cpu', 'cuda', 'mps']
```

## Testing
- 9 new tests covering valid configs, invalid values, typo detection, and warning output
- All existing tests pass
- No new dependencies (uses stdlib `difflib`)