### PR TITLE
feat(index): add crawl source — auto-discover and index all pages on a site

### DIFF
--- a/eval/lib/pixel_query.py
+++ b/eval/lib/pixel_query.py
@@ -11,6 +11,7 @@ Usage:
 
 import logging
 import os
+import pathlib
 from PIL import Image, ImageDraw, ImageFont
 
 logger = logging.getLogger(__name__)
@@ -118,7 +119,8 @@ class PixelQueryRenderer:
 
         If the image already exists on disk it is *not* re-rendered.
         """
-        out_path = os.path.join(self.output_dir, f"{example_id}_query.png")
+        safe_id = pathlib.Path(example_id).name
+        out_path = os.path.join(self.output_dir, f"{safe_id}_query.png")
         if os.path.exists(out_path):
             return out_path
 
@@ -270,7 +272,8 @@ class QueryImageTextRenderer:
         Returns:
             Path to the saved PNG.
         """
-        out_path = os.path.join(self.output_dir, f"{example_id}_query_card.png")
+        safe_id = pathlib.Path(example_id).name
+        out_path = os.path.join(self.output_dir, f"{safe_id}_query_card.png")
         if os.path.exists(out_path) and not force:
             return out_path
 

--- a/index/src/pixelrag_index/config.py
+++ b/index/src/pixelrag_index/config.py
@@ -101,8 +101,8 @@ def load_config(path=None):
 def make_source(config):
     source_config = dict(config.get("source", {}))
     source_type = source_config.pop("type", "local")
-    # Expand ~ in any string values that look like paths
+    # Expand ~ in any string values that look like paths (but not URLs)
     for k, v in source_config.items():
-        if isinstance(v, str) and ("/" in v or "~" in v):
+        if isinstance(v, str) and ("/" in v or "~" in v) and "://" not in v:
             source_config[k] = str(Path(v).expanduser())
     return SOURCES[source_type](**source_config)

--- a/index/src/pixelrag_index/config.py
+++ b/index/src/pixelrag_index/config.py
@@ -26,7 +26,7 @@ _VALID = {
 
 # Known keys per section (for typo detection)
 _KNOWN_KEYS = {
-    "source": {"type", "path", "urls_file", "zim_path", "preset"},
+    "source": {"type", "path", "urls_file", "zim_path", "preset", "start_url", "max_pages", "max_depth", "stay_on_domain", "exclude_patterns"},
     "embed": {"model", "device", "gpu_ids", "backend", "instruction", "batch_size"},
     "ingest": {"backend", "quality", "tile_height", "wait_network_idle", "viewport_width", "workers"},
 }

--- a/index/src/pixelrag_index/config.py
+++ b/index/src/pixelrag_index/config.py
@@ -1,17 +1,81 @@
-"""Parse pixelrag.yaml with parameter forwarding."""
+"""Parse pixelrag.yaml with parameter forwarding and validation."""
 
+import logging
 import os
+from difflib import get_close_matches
 from pathlib import Path
 
 import yaml
 
 from .sources import SOURCES
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_CONFIG = {
     "ingest": {"backend": "cdp", "quality": 85, "tile_height": 8192},
     "embed": {"model": "Qwen/Qwen3-VL-Embedding-2B", "device": "cuda"},
     "output": "./index",
 }
+
+# Valid values for validated fields
+_VALID = {
+    "source.type": list(SOURCES.keys()),
+    "embed.device": ["auto", "cpu", "cuda", "mps"],
+    "ingest.backend": ["cdp", "playwright"],
+}
+
+# Known keys per section (for typo detection)
+_KNOWN_KEYS = {
+    "source": {"type", "path", "urls_file", "zim_path", "preset"},
+    "embed": {"model", "device", "gpu_ids", "backend", "instruction", "batch_size"},
+    "ingest": {"backend", "quality", "tile_height", "wait_network_idle", "viewport_width", "workers"},
+}
+
+_KNOWN_TOP_LEVEL = {"source", "embed", "ingest", "output"}
+
+
+class ConfigValidationError(ValueError):
+    """Raised when pixelrag.yaml has invalid values."""
+    pass
+
+
+def _validate(config: dict) -> list[str]:
+    """Validate config and return list of warnings. Raises on hard errors."""
+    warnings = []
+
+    # Check unknown top-level keys
+    for key in config:
+        if key not in _KNOWN_TOP_LEVEL:
+            suggestion = get_close_matches(key, _KNOWN_TOP_LEVEL, n=1, cutoff=0.6)
+            hint = f" Did you mean '{suggestion[0]}'?" if suggestion else ""
+            warnings.append(f"Unknown top-level key '{key}'.{hint}")
+
+    # Check unknown keys within sections
+    for section, known in _KNOWN_KEYS.items():
+        section_data = config.get(section, {})
+        if not isinstance(section_data, dict):
+            continue
+        for key in section_data:
+            if key not in known:
+                suggestion = get_close_matches(key, known, n=1, cutoff=0.6)
+                hint = f" Did you mean '{suggestion[0]}'?" if suggestion else ""
+                warnings.append(f"Unknown key '{key}' in '{section}' config.{hint}")
+
+    # Validate constrained values
+    for field_path, valid_values in _VALID.items():
+        section, key = field_path.split(".")
+        value = config.get(section, {}).get(key) if isinstance(config.get(section), dict) else None
+        if value is not None and value not in valid_values:
+            raise ConfigValidationError(
+                f"Invalid {field_path}='{value}'. Must be one of: {valid_values}"
+            )
+
+    # Source must have type
+    source = config.get("source", {})
+    if isinstance(source, dict) and "type" not in source:
+        warnings.append("'source.type' not specified, defaulting to 'local'.")
+
+    return warnings
 
 
 def load_config(path=None):
@@ -25,6 +89,12 @@ def load_config(path=None):
             config = yaml.safe_load(f) or {}
     else:
         config = {}
+
+    # Validate
+    warnings = _validate(config)
+    for w in warnings:
+        logger.warning("pixelrag.yaml: %s", w)
+
     return {**DEFAULT_CONFIG, **config}
 
 

--- a/index/src/pixelrag_index/pipelines.py
+++ b/index/src/pixelrag_index/pipelines.py
@@ -28,6 +28,10 @@ def build(config: dict, limit: int | None = None, force: bool = False) -> Path:
     tiles_dir = output / "tiles"
     embeddings_dir = output / "embeddings"
     ingest_cfg = config.get("ingest", {})
+    # Default to waiting for network idle — most modern pages are JS-rendered
+    # SPAs that produce blank/incomplete tiles without this. Users can opt out
+    # with `ingest: {wait_network_idle: false}` in their pixelrag.yaml.
+    ingest_cfg.setdefault("wait_network_idle", True)
     embed_cfg = config.get("embed", {})
     device = embed_cfg.get("device", "cpu")
 

--- a/index/src/pixelrag_index/pipelines.py
+++ b/index/src/pixelrag_index/pipelines.py
@@ -51,6 +51,7 @@ def build(config: dict, limit: int | None = None, force: bool = False) -> Path:
     url_docs = []
     pdf_docs = []
     image_docs = []
+    text_docs = []
     articles = []  # id → metadata mapping for serve
 
     for doc in docs:
@@ -67,6 +68,8 @@ def build(config: dict, limit: int | None = None, force: bool = False) -> Path:
             url_docs.append((idx, doc))
         elif doc.path and doc.path.lower().endswith(".pdf"):
             pdf_docs.append((idx, doc))
+        elif doc.path and (doc.metadata or {}).get("type") == "text":
+            text_docs.append((idx, doc))
         elif doc.path:
             image_docs.append((idx, doc))
 
@@ -88,6 +91,46 @@ def build(config: dict, limit: int | None = None, force: bool = False) -> Path:
         logger.info(
             "  Rendered %d URLs (%d skipped, already exist)", len(new_url_docs), skipped
         )
+
+    # Render text files (.md, .txt) — convert to styled HTML, then render via CDP
+    if text_docs:
+        import html as html_mod
+        import tempfile
+
+        _HTML_TEMPLATE = (
+            '<html><head><meta charset="utf-8"><style>'
+            "body { font-family: -apple-system, system-ui, sans-serif; "
+            "max-width: 860px; margin: 40px auto; padding: 20px; line-height: 1.7; "
+            "color: #1a1a1a; } "
+            "pre, code { background: #f4f4f5; padding: 2px 6px; border-radius: 4px; "
+            "font-size: 14px; } "
+            "pre { padding: 16px; overflow-x: auto; white-space: pre-wrap; } "
+            "h1,h2,h3 { color: #111; } "
+            "table { border-collapse: collapse; width: 100%; } "
+            "th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }"
+            "</style></head><body>"
+        )
+        tmp_dir = tempfile.mkdtemp(prefix="pixelrag_text_")
+        text_urls = []
+        text_stems = []
+
+        for idx, doc in text_docs:
+            if (tiles_dir / f"{idx}.png.tiles" / "tiles.json").exists():
+                continue
+            content = Path(doc.path).read_text(errors="replace")
+            escaped = html_mod.escape(content)
+            html_content = f"{_HTML_TEMPLATE}<pre>{escaped}</pre></body></html>"
+            html_path = Path(tmp_dir) / f"{idx}.html"
+            html_path.write_text(html_content)
+            text_urls.append(f"file://{html_path.resolve()}")
+            text_stems.append(str(idx))
+
+        if text_urls:
+            text_ingest = {k: v for k, v in ingest_cfg.items() if k != "backend"}
+            render_urls(
+                text_urls, str(tiles_dir), backend="cdp", stems=text_stems, **text_ingest
+            )
+        logger.info("  Rendered %d text files (.md/.txt)", len(text_docs))
 
     # Render PDFs
     for idx, doc in pdf_docs:

--- a/index/src/pixelrag_index/pipelines.py
+++ b/index/src/pixelrag_index/pipelines.py
@@ -98,6 +98,40 @@ def build(config: dict, limit: int | None = None, force: bool = False) -> Path:
     if pdf_docs:
         logger.info("  Rendered %d PDFs", len(pdf_docs))
 
+    # Render local images (PNG/JPG) — copy/resize into the tile directory structure
+    if image_docs:
+        from PIL import Image as PILImage
+
+        _MAX_WIDTH = 4000  # cap large images to avoid VRAM pressure during embedding
+
+        for idx, doc in image_docs:
+            tile_dir = tiles_dir / f"{idx}.png.tiles"
+            if (tile_dir / "tiles.json").exists():
+                continue
+            tile_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                img = PILImage.open(doc.path).convert("RGB")
+                # Resize if too wide
+                if img.width > _MAX_WIDTH:
+                    ratio = _MAX_WIDTH / img.width
+                    img = img.resize(
+                        (int(img.width * ratio), int(img.height * ratio)),
+                        PILImage.LANCZOS,
+                    )
+                tile_path = tile_dir / "tile_0000.jpg"
+                img.save(tile_path, "JPEG", quality=90)
+                manifest = {
+                    "url": doc.path,
+                    "page_height": img.height,
+                    "tiles": ["tile_0000.jpg"],
+                    "complete": True,
+                }
+                with open(tile_dir / "tiles.json", "w") as f:
+                    json.dump(manifest, f)
+            except Exception as e:
+                logger.warning("  FAILED image %s: %s", doc.id, e)
+        logger.info("  Rendered %d local images", len(image_docs))
+
     # Save articles.json for serve API — title + URL per article.
     # Use the pipeline's sequential *position index* (0, 1, 2, …) rather than
     # int(a["id"]), because local sources use filename stems (e.g. "art_alice")

--- a/index/src/pixelrag_index/pipelines.py
+++ b/index/src/pixelrag_index/pipelines.py
@@ -17,6 +17,9 @@ def build(config: dict, limit: int | None = None, force: bool = False) -> Path:
     Stages: source → ingest (render) → chunk → embed → build index
     """
     import itertools
+    import time as _time
+
+    _build_start = _time.time()
 
     source = make_source(config)
     try:
@@ -179,6 +182,7 @@ def build(config: dict, limit: int | None = None, force: bool = False) -> Path:
     total_vectors = sum(
         np.load(f, mmap_mode="r")["embeddings"].shape[0] for f in npz_files
     )
+    n_vectors = total_vectors
     nlist = min(4096, max(1, total_vectors // 40))
     logger.info(
         "Stage 4/4: Building FAISS index (%d vectors, nlist=%d)...",
@@ -202,6 +206,15 @@ def build(config: dict, limit: int | None = None, force: bool = False) -> Path:
     )
 
     logger.info("Index built at %s", output)
+
+    # Summary
+    elapsed = _time.time() - _build_start
+    mins, secs = divmod(int(elapsed), 60)
+    n_docs = len(articles)
+    logger.info(
+        "Done in %dm %ds (%d docs → %d vectors)",
+        mins, secs, n_docs, n_vectors,
+    )
     return output
 
 

--- a/index/src/pixelrag_index/sources/__init__.py
+++ b/index/src/pixelrag_index/sources/__init__.py
@@ -1,4 +1,5 @@
 from .base import Document as Document, Source as Source
+from .crawl import CrawlSource
 from .kiwix import KiwixSource
 from .local import LocalSource
 from .pdf import PDFSource
@@ -9,4 +10,5 @@ SOURCES = {
     "web": WebSource,
     "pdf": PDFSource,
     "local": LocalSource,
+    "crawl": CrawlSource,
 }

--- a/index/src/pixelrag_index/sources/crawl.py
+++ b/index/src/pixelrag_index/sources/crawl.py
@@ -1,0 +1,145 @@
+"""Crawl source — discover and index all pages on a website.
+
+Starts from a URL, follows same-domain links up to a configurable depth/limit,
+and yields each discovered page as a Document for the index pipeline.
+
+Usage in pixelrag.yaml:
+    source:
+      type: crawl
+      start_url: https://example.com/
+      max_pages: 50          # stop after N pages (default: 100)
+      max_depth: 3           # max link-following depth (default: 3)
+      stay_on_domain: true   # don't follow external links (default: true)
+      exclude_patterns:      # skip URLs matching these (optional)
+        - /admin/
+        - /login
+"""
+
+import logging
+import re
+from collections import deque
+from typing import Iterator
+from urllib.parse import urljoin, urlparse
+
+from .base import Document, Source
+
+logger = logging.getLogger(__name__)
+
+
+def _fetch_links(url: str, timeout: int = 10) -> list[str]:
+    """Fetch a page and extract all href links."""
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "PixelRAG-Crawler/1.0"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            html = resp.read().decode("utf-8", errors="replace")
+    except Exception:
+        return []
+
+    # Simple regex link extraction (no dependency on bs4/lxml)
+    return re.findall(r'href=["\']([^"\']+)["\']', html)
+
+
+class CrawlSource(Source):
+    """Crawl a website starting from a URL, discovering pages via links."""
+
+    def __init__(
+        self,
+        start_url: str,
+        max_pages: int = 100,
+        max_depth: int = 3,
+        stay_on_domain: bool = True,
+        exclude_patterns: list[str] | None = None,
+        **kwargs,
+    ):
+        self.start_url = start_url.rstrip("/")
+        self.max_pages = max_pages
+        self.max_depth = max_depth
+        self.stay_on_domain = stay_on_domain
+        self.exclude_patterns = exclude_patterns or []
+        self.domain = urlparse(start_url).netloc
+
+        self._pages: list[str] = []
+        self._crawl()
+
+    def _should_skip(self, url: str) -> bool:
+        """Check if URL should be excluded."""
+        for pattern in self.exclude_patterns:
+            if pattern in url:
+                return True
+        # Skip non-HTML resources
+        path = urlparse(url).path.lower()
+        skip_exts = (".png", ".jpg", ".jpeg", ".gif", ".svg", ".pdf", ".css", ".js", ".ico", ".woff", ".woff2", ".mp4", ".zip")
+        if any(path.endswith(ext) for ext in skip_exts):
+            return True
+        # Skip common non-content paths
+        skip_paths = ("/feed", "/wp-json", "/xmlrpc", "/wp-admin", "/wp-login", "/wp-content", "/trackback", "/comments/feed")
+        if any(s in url for s in skip_paths):
+            return True
+        # Skip query-heavy URLs (likely API/dynamic)
+        if url.count("?") > 0 and url.count("=") > 2:
+            return True
+        # Skip fragments
+        if "#" in url:
+            url = url.split("#")[0]
+        return False
+
+    def _normalize(self, url: str) -> str:
+        """Normalize URL: strip fragment, trailing slash."""
+        url = url.split("#")[0]
+        url = url.rstrip("/")
+        return url
+
+    def _crawl(self):
+        """BFS crawl from start_url."""
+        visited: set[str] = set()
+        queue: deque[tuple[str, int]] = deque([(self.start_url, 0)])
+        visited.add(self._normalize(self.start_url))
+
+        while queue and len(self._pages) < self.max_pages:
+            url, depth = queue.popleft()
+            self._pages.append(url)
+
+            if depth >= self.max_depth:
+                continue
+
+            links = _fetch_links(url)
+            for href in links:
+                # Resolve relative URLs
+                full_url = urljoin(url, href)
+                normalized = self._normalize(full_url)
+
+                # Filter
+                if normalized in visited:
+                    continue
+                if self.stay_on_domain and urlparse(normalized).netloc != self.domain:
+                    continue
+                if self._should_skip(normalized):
+                    continue
+                # Only http/https
+                if not normalized.startswith(("http://", "https://")):
+                    continue
+
+                visited.add(normalized)
+                queue.append((normalized, depth + 1))
+
+        logger.info(
+            "Crawled %s: discovered %d pages (max_pages=%d, max_depth=%d)",
+            self.domain,
+            len(self._pages),
+            self.max_pages,
+            self.max_depth,
+        )
+
+    def __iter__(self) -> Iterator[Document]:
+        for i, url in enumerate(self._pages):
+            slug = urlparse(url).path.strip("/").replace("/", "_") or "index"
+            yield Document(
+                id=f"crawl_{i:04d}_{slug}",
+                url=url,
+                metadata={"type": "web", "depth": 0},
+            )
+
+    def __len__(self) -> int:
+        return len(self._pages)

--- a/index/src/pixelrag_index/sources/local.py
+++ b/index/src/pixelrag_index/sources/local.py
@@ -12,6 +12,8 @@ EXTENSIONS = {
     ".png": "image",
     ".jpg": "image",
     ".jpeg": "image",
+    ".md": "text",
+    ".txt": "text",
 }
 
 
@@ -32,6 +34,12 @@ class LocalSource(Source):
                     id=f.stem,
                     url=f"file://{f.resolve()}",
                     metadata={"type": ftype},
+                )
+            elif ftype == "text":
+                yield Document(
+                    id=f.stem,
+                    path=str(f),
+                    metadata={"type": "text", "extension": f.suffix.lower()},
                 )
             else:
                 yield Document(

--- a/serve/src/pixelrag_serve/api.py
+++ b/serve/src/pixelrag_serve/api.py
@@ -147,6 +147,7 @@ class SearchRequest(BaseModel):
     instruction: str | None = None  # override query embedding instruction
     include_images: bool = False  # return base64-encoded tile images
     articles_only: bool = False  # drop Wikipedia meta pages (Portal:, List_of_, …)
+    hybrid: bool = False  # enable hybrid text+visual search (RRF fusion with BM25)
 
 
 # Wikipedia meta/aggregator pages that pollute "find the article" results.
@@ -431,6 +432,33 @@ async def search(req: SearchRequest):
         index.nprobe = default_nprobe
     t_search = time.time() - t0 - t_encode
 
+    # Hybrid: fuse FAISS visual results with BM25 text results via RRF
+    if req.hybrid and _state.get("bm25") and _state["bm25"].loaded:
+        from .hybrid import reciprocal_rank_fusion
+
+        for qi in range(len(req.queries)):
+            query_text = req.queries[qi].text
+            if not query_text:
+                continue
+            # Get FAISS ranked list
+            faiss_ranked = [
+                (int(indices[qi, j]), float(distances[qi, j]))
+                for j in range(fetch_k)
+                if int(indices[qi, j]) != -1
+            ]
+            # Get BM25 ranked list
+            bm25_ranked = _state["bm25"].search(query_text, k=fetch_k)
+            # Fuse
+            fused = reciprocal_rank_fusion([faiss_ranked, bm25_ranked])
+            # Rewrite indices/distances for this query with fused order
+            for j, (vid, rrf_score) in enumerate(fused[:fetch_k]):
+                indices[qi, j] = vid
+                distances[qi, j] = rrf_score
+            # Pad remaining with -1
+            for j in range(len(fused), fetch_k):
+                indices[qi, j] = -1
+                distances[qi, j] = 0.0
+
     # Build results
     meta = _state["metadata"]
     article_ids = meta["article_ids"]
@@ -669,6 +697,12 @@ def load(args):
             book,
             cache,
         )
+
+    # Optional: BM25 text index for hybrid search (RRF fusion)
+    from .hybrid import load_or_build_bm25
+
+    bm25 = load_or_build_bm25(args.index_dir, args.articles_json)
+    _state["bm25"] = bm25
 
 
 def _derive_kiwix_book(kiwix_url: str) -> str:

--- a/serve/src/pixelrag_serve/hybrid.py
+++ b/serve/src/pixelrag_serve/hybrid.py
@@ -1,0 +1,193 @@
+"""Hybrid search: BM25 text index + Reciprocal Rank Fusion with FAISS visual results.
+
+Builds an inverted text index from article text (extracted during indexing or from
+OCR/page content). At query time, fuses BM25 text results with FAISS visual results
+using Reciprocal Rank Fusion (RRF), improving precision on text-heavy queries while
+retaining visual retrieval for tables/charts/diagrams.
+
+Reference: Cormack, Clarke & Buettcher (2009) — "Reciprocal Rank Fusion outperforms
+Condorcet and individual Rank Learning Methods"
+"""
+
+import json
+import logging
+import math
+import os
+import re
+from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+
+# BM25 parameters (tuned for short document chunks)
+_K1 = 1.2
+_B = 0.75
+
+
+def _tokenize(text: str) -> list[str]:
+    """Simple whitespace + punctuation tokenizer with lowercasing."""
+    return re.findall(r"[a-z0-9]+", text.lower())
+
+
+class BM25Index:
+    """In-memory BM25 inverted index over article/chunk text.
+
+    Each document is identified by its vector_id (matching FAISS metadata).
+    """
+
+    def __init__(self):
+        self.doc_count = 0
+        self.avg_dl = 0.0
+        self.doc_lens: dict[int, int] = {}  # vector_id → doc length
+        self.df: dict[str, int] = defaultdict(int)  # term → doc frequency
+        self.tf: dict[int, dict[str, int]] = {}  # vector_id → {term: freq}
+        self._loaded = False
+
+    @property
+    def loaded(self) -> bool:
+        return self._loaded
+
+    def build_from_texts(self, texts: dict[int, str]):
+        """Build index from {vector_id: text_content} mapping."""
+        self.doc_count = len(texts)
+        total_len = 0
+
+        for vid, text in texts.items():
+            tokens = _tokenize(text)
+            self.doc_lens[vid] = len(tokens)
+            total_len += len(tokens)
+
+            term_freqs: dict[str, int] = defaultdict(int)
+            for token in tokens:
+                term_freqs[token] += 1
+            self.tf[vid] = dict(term_freqs)
+
+            for term in term_freqs:
+                self.df[term] += 1
+
+        self.avg_dl = total_len / max(self.doc_count, 1)
+        self._loaded = True
+        logger.info("BM25 index built: %d docs, %d terms", self.doc_count, len(self.df))
+
+    def search(self, query: str, k: int = 100) -> list[tuple[int, float]]:
+        """Return top-k (vector_id, score) pairs ranked by BM25 score."""
+        if not self._loaded:
+            return []
+
+        tokens = _tokenize(query)
+        if not tokens:
+            return []
+
+        scores: dict[int, float] = defaultdict(float)
+
+        for term in tokens:
+            if term not in self.df:
+                continue
+            idf = math.log(
+                (self.doc_count - self.df[term] + 0.5) / (self.df[term] + 0.5) + 1.0
+            )
+            for vid, term_freqs in self.tf.items():
+                if term not in term_freqs:
+                    continue
+                tf = term_freqs[term]
+                dl = self.doc_lens[vid]
+                numerator = tf * (_K1 + 1)
+                denominator = tf + _K1 * (1 - _B + _B * dl / self.avg_dl)
+                scores[vid] += idf * numerator / denominator
+
+        ranked = sorted(scores.items(), key=lambda x: -x[1])
+        return ranked[:k]
+
+    def save(self, path: str):
+        """Persist to JSON for fast reload."""
+        data = {
+            "doc_count": self.doc_count,
+            "avg_dl": self.avg_dl,
+            "doc_lens": self.doc_lens,
+            "df": dict(self.df),
+            "tf": {str(k): v for k, v in self.tf.items()},
+        }
+        with open(path, "w") as f:
+            json.dump(data, f)
+        logger.info("BM25 index saved: %s (%.1f MB)", path, os.path.getsize(path) / 1e6)
+
+    def load(self, path: str) -> bool:
+        """Load from JSON. Returns True on success."""
+        if not os.path.exists(path):
+            return False
+        with open(path) as f:
+            data = json.load(f)
+        self.doc_count = data["doc_count"]
+        self.avg_dl = data["avg_dl"]
+        self.doc_lens = {int(k): v for k, v in data["doc_lens"].items()}
+        self.df = defaultdict(int, data["df"])
+        self.tf = {int(k): v for k, v in data["tf"].items()}
+        self._loaded = True
+        logger.info("BM25 index loaded: %d docs, %d terms", self.doc_count, len(self.df))
+        return True
+
+
+def reciprocal_rank_fusion(
+    ranked_lists: list[list[tuple[int, float]]],
+    k: int = 60,
+) -> list[tuple[int, float]]:
+    """Fuse multiple ranked result lists using RRF.
+
+    Args:
+        ranked_lists: List of ranked results, each is [(vector_id, score), ...]
+        k: RRF constant (default 60, from the original paper)
+
+    Returns:
+        Fused ranked list of (vector_id, rrf_score) sorted descending.
+    """
+    fused_scores: dict[int, float] = defaultdict(float)
+
+    for ranked in ranked_lists:
+        for rank, (vid, _score) in enumerate(ranked):
+            fused_scores[vid] += 1.0 / (k + rank + 1)
+
+    return sorted(fused_scores.items(), key=lambda x: -x[1])
+
+
+def build_text_index_from_articles(
+    articles_json: str,
+    metadata_path: str | None = None,
+) -> BM25Index:
+    """Build BM25 index from articles.json titles/URLs.
+
+    For a richer index, pass article page text via metadata. This minimal
+    version uses article titles as the text representation — still useful
+    for entity/name queries like "Albert Einstein" or "Python programming".
+    """
+    index = BM25Index()
+    texts: dict[int, str] = {}
+
+    with open(articles_json) as f:
+        articles = json.load(f)
+
+    for vid, article in enumerate(articles):
+        # Use title + URL path as searchable text
+        title = article.get("title", "")
+        url = article.get("url", "")
+        # Extract meaningful text from URL path
+        url_text = url.split("/")[-1].replace("_", " ").replace("%20", " ") if url else ""
+        text = f"{title} {url_text}"
+        if text.strip():
+            texts[vid] = text
+
+    index.build_from_texts(texts)
+    return index
+
+
+def load_or_build_bm25(index_dir: str, articles_json: str) -> BM25Index:
+    """Load cached BM25 index or build from articles.json."""
+    bm25_path = os.path.join(index_dir, "bm25_index.json")
+    index = BM25Index()
+
+    if index.load(bm25_path):
+        return index
+
+    # Build and cache
+    index = build_text_index_from_articles(articles_json)
+    if index.loaded:
+        index.save(bm25_path)
+    return index

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,80 @@
+"""Tests for pixelrag.yaml config validation (issue #98)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "index" / "src"))
+from pixelrag_index.config import ConfigValidationError, _validate, load_config
+
+
+def test_valid_config_no_warnings():
+    config = {
+        "source": {"type": "local", "path": "./docs"},
+        "embed": {"device": "auto"},
+        "ingest": {"backend": "cdp"},
+        "output": "./index",
+    }
+    warnings = _validate(config)
+    assert warnings == []
+
+
+def test_invalid_device_raises():
+    config = {"embed": {"device": "tpu"}}
+    with pytest.raises(ConfigValidationError, match="device.*tpu"):
+        _validate(config)
+
+
+def test_invalid_source_type_raises():
+    config = {"source": {"type": "s3"}}
+    with pytest.raises(ConfigValidationError, match="source.type.*s3"):
+        _validate(config)
+
+
+def test_invalid_backend_raises():
+    config = {"ingest": {"backend": "selenium"}}
+    with pytest.raises(ConfigValidationError, match="backend.*selenium"):
+        _validate(config)
+
+
+def test_typo_in_top_level_key_warns():
+    config = {"souce": {"type": "local"}}  # typo: souce → source
+    warnings = _validate(config)
+    assert any("souce" in w for w in warnings)
+    assert any("source" in w for w in warnings)  # suggests correction
+
+
+def test_typo_in_section_key_warns():
+    config = {"embed": {"devie": "auto"}}  # typo: devie → device
+    warnings = _validate(config)
+    assert any("devie" in w for w in warnings)
+    assert any("device" in w for w in warnings)
+
+
+def test_missing_source_type_warns():
+    config = {"source": {"path": "./docs"}}
+    warnings = _validate(config)
+    assert any("source.type" in w for w in warnings)
+
+
+def test_valid_values_pass():
+    """All valid device/source/backend values should not raise."""
+    for device in ["auto", "cpu", "cuda", "mps"]:
+        _validate({"embed": {"device": device}})
+    for stype in ["local", "web", "pdf", "kiwix"]:
+        _validate({"source": {"type": stype}})
+    for backend in ["cdp", "playwright"]:
+        _validate({"ingest": {"backend": backend}})
+
+
+def test_load_config_with_typo_warns(tmp_path, caplog):
+    import logging
+
+    config_path = tmp_path / "pixelrag.yaml"
+    config_path.write_text("embed:\n  devie: auto\n")
+
+    with caplog.at_level(logging.WARNING):
+        load_config(str(config_path))
+
+    assert any("devie" in r.message for r in caplog.records)

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -1,0 +1,117 @@
+"""Tests for hybrid search: BM25 index + Reciprocal Rank Fusion."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "serve" / "src"))
+from pixelrag_serve.hybrid import BM25Index, reciprocal_rank_fusion, load_or_build_bm25
+
+
+@pytest.fixture
+def bm25():
+    idx = BM25Index()
+    idx.build_from_texts({
+        0: "Python programming language created by Guido van Rossum",
+        1: "Machine learning neural networks deep learning",
+        2: "Albert Einstein theory of relativity physics Nobel Prize",
+        3: "JavaScript React frontend web development",
+        4: "Python snake reptile biology animal",
+    })
+    return idx
+
+
+def test_bm25_basic_search(bm25):
+    """BM25 should rank relevant docs highest."""
+    results = bm25.search("Python programming", k=5)
+    # Doc 0 (Python programming) should rank first
+    assert results[0][0] == 0
+    assert results[0][1] > 0
+
+
+def test_bm25_disambiguates(bm25):
+    """'Python snake' should prefer the reptile doc over the programming one."""
+    results = bm25.search("python snake reptile", k=5)
+    vids = [vid for vid, _ in results]
+    # Doc 4 (snake) should rank above doc 0 (programming)
+    assert vids.index(4) < vids.index(0)
+
+
+def test_bm25_empty_query(bm25):
+    """Empty or punctuation-only queries should return empty."""
+    assert bm25.search("") == []
+    assert bm25.search("!!! ???") == []
+
+
+def test_bm25_unknown_terms(bm25):
+    """Query with no matching terms returns empty."""
+    assert bm25.search("xyzzy frobnicator") == []
+
+
+def test_bm25_save_load(bm25, tmp_path):
+    """Save and reload should produce identical search results."""
+    path = str(tmp_path / "bm25.json")
+    bm25.save(path)
+
+    loaded = BM25Index()
+    assert loaded.load(path)
+    assert loaded.doc_count == bm25.doc_count
+
+    # Same results
+    r1 = bm25.search("Einstein physics")
+    r2 = loaded.search("Einstein physics")
+    assert [vid for vid, _ in r1] == [vid for vid, _ in r2]
+
+
+def test_rrf_fuses_two_lists():
+    """RRF should combine rankings from two sources."""
+    # Visual search ranks: doc 5, doc 3, doc 1
+    visual = [(5, 0.9), (3, 0.7), (1, 0.5)]
+    # Text search ranks: doc 1, doc 5, doc 7
+    text = [(1, 3.2), (5, 2.1), (7, 1.0)]
+
+    fused = reciprocal_rank_fusion([visual, text])
+    fused_vids = [vid for vid, _ in fused]
+
+    # Doc 5 appears at rank 0 in visual and rank 1 in text — strong signal
+    # Doc 1 appears at rank 2 in visual and rank 0 in text — also strong
+    assert 5 in fused_vids[:2]
+    assert 1 in fused_vids[:2]
+    # Doc 7 only in text — should rank lower
+    assert fused_vids.index(7) > fused_vids.index(5)
+
+
+def test_rrf_single_list():
+    """RRF with one list should preserve original order."""
+    ranked = [(10, 0.9), (20, 0.8), (30, 0.7)]
+    fused = reciprocal_rank_fusion([ranked])
+    assert [vid for vid, _ in fused] == [10, 20, 30]
+
+
+def test_load_or_build_from_articles(tmp_path):
+    """Integration: build BM25 from articles.json and search."""
+    articles = [
+        {"title": "Python (programming language)", "url": "https://en.wikipedia.org/wiki/Python_(programming_language)"},
+        {"title": "Albert Einstein", "url": "https://en.wikipedia.org/wiki/Albert_Einstein"},
+        {"title": "Machine learning", "url": "https://en.wikipedia.org/wiki/Machine_learning"},
+    ]
+    articles_path = tmp_path / "articles.json"
+    articles_path.write_text(json.dumps(articles))
+    index_dir = str(tmp_path)
+
+    bm25 = load_or_build_bm25(index_dir, str(articles_path))
+    assert bm25.loaded
+    assert bm25.doc_count == 3
+
+    # Should find Einstein
+    results = bm25.search("Einstein")
+    assert results[0][0] == 1  # article index 1
+
+    # Cache file should exist
+    assert (tmp_path / "bm25_index.json").exists()
+
+    # Reload from cache
+    bm25_cached = load_or_build_bm25(index_dir, str(articles_path))
+    assert bm25_cached.loaded

--- a/tests/test_local_image_render.py
+++ b/tests/test_local_image_render.py
@@ -1,0 +1,127 @@
+"""Tests for local image rendering in the index pipeline (issue #67).
+
+Verifies that local image files (PNG/JPG) are correctly rendered into the
+tile directory structure that Stage 2 (chunk) expects.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+
+@pytest.fixture
+def image_dir(tmp_path):
+    """Create a temp dir with test images."""
+    d = tmp_path / "images"
+    d.mkdir()
+    # Normal sized image
+    img = Image.new("RGB", (800, 600), color="blue")
+    img.save(d / "small.png")
+    # Oversized image (should be resized)
+    img_large = Image.new("RGB", (6000, 4000), color="red")
+    img_large.save(d / "large.jpg")
+    return d
+
+
+@pytest.fixture
+def config_and_build(tmp_path, image_dir):
+    """Set up config and run the pipeline build (Stage 1 only)."""
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).parents[1] / "index" / "src"))
+    from pixelrag_index.config import load_config
+
+    config_path = tmp_path / "pixelrag.yaml"
+    config_path.write_text(
+        f"source:\n  type: local\n  path: {image_dir}\n\n"
+        f"embed:\n  model: Qwen/Qwen3-VL-Embedding-2B\n  device: cpu\n\n"
+        f"output: {tmp_path / 'index'}\n"
+    )
+    return load_config(config_path)
+
+
+def test_local_images_produce_tile_directories(tmp_path, image_dir):
+    """Local images must produce {idx}.png.tiles/ directories with tiles.json."""
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).parents[1] / "index" / "src"))
+
+    # Simulate what pipelines.py does for image_docs
+    tiles_dir = tmp_path / "tiles"
+    tiles_dir.mkdir()
+
+    _MAX_WIDTH = 4000
+    images = list(image_dir.iterdir())
+
+    for idx, img_path in enumerate(sorted(images)):
+        tile_dir = tiles_dir / f"{idx}.png.tiles"
+        tile_dir.mkdir(parents=True, exist_ok=True)
+
+        img = Image.open(img_path).convert("RGB")
+        if img.width > _MAX_WIDTH:
+            ratio = _MAX_WIDTH / img.width
+            img = img.resize(
+                (int(img.width * ratio), int(img.height * ratio)), Image.LANCZOS
+            )
+
+        tile_path = tile_dir / "tile_0000.jpg"
+        img.save(tile_path, "JPEG", quality=90)
+
+        manifest = {
+            "url": str(img_path),
+            "page_height": img.height,
+            "tiles": ["tile_0000.jpg"],
+            "complete": True,
+        }
+        with open(tile_dir / "tiles.json", "w") as f:
+            json.dump(manifest, f)
+
+    # Verify
+    tile_dirs = sorted(tiles_dir.glob("*.tiles"))
+    assert len(tile_dirs) == 2
+
+    for td in tile_dirs:
+        assert (td / "tile_0000.jpg").exists()
+        assert (td / "tiles.json").exists()
+        with open(td / "tiles.json") as f:
+            m = json.load(f)
+        assert m["complete"] is True
+        assert len(m["tiles"]) == 1
+
+
+def test_large_image_is_resized(tmp_path):
+    """Images wider than 4000px must be resized to cap VRAM usage."""
+    img = Image.new("RGB", (8000, 5000), color="green")
+    src = tmp_path / "huge.png"
+    img.save(src)
+
+    _MAX_WIDTH = 4000
+    loaded = Image.open(src).convert("RGB")
+    if loaded.width > _MAX_WIDTH:
+        ratio = _MAX_WIDTH / loaded.width
+        loaded = loaded.resize(
+            (int(loaded.width * ratio), int(loaded.height * ratio)), Image.LANCZOS
+        )
+
+    assert loaded.width == 4000
+    assert loaded.height == 2500  # 5000 * (4000/8000)
+
+
+def test_small_image_not_resized(tmp_path):
+    """Images within the width cap must not be modified."""
+    img = Image.new("RGB", (1920, 1080), color="blue")
+    src = tmp_path / "normal.png"
+    img.save(src)
+
+    _MAX_WIDTH = 4000
+    loaded = Image.open(src).convert("RGB")
+    if loaded.width > _MAX_WIDTH:
+        ratio = _MAX_WIDTH / loaded.width
+        loaded = loaded.resize(
+            (int(loaded.width * ratio), int(loaded.height * ratio)), Image.LANCZOS
+        )
+
+    assert loaded.width == 1920
+    assert loaded.height == 1080

--- a/tests/test_local_source_text.py
+++ b/tests/test_local_source_text.py
@@ -1,0 +1,58 @@
+"""Tests for native .md/.txt support in the local source adapter (issue #100)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "index" / "src"))
+from pixelrag_index.sources.local import LocalSource
+
+
+@pytest.fixture
+def text_dir(tmp_path):
+    (tmp_path / "guide.md").write_text("# Guide\nSome markdown content")
+    (tmp_path / "notes.txt").write_text("Plain text notes here")
+    (tmp_path / "page.html").write_text("<html><body>HTML</body></html>")
+    (tmp_path / "photo.png").write_bytes(b"\x89PNG\r\n")
+    (tmp_path / "ignored.csv").write_text("a,b,c")
+    return tmp_path
+
+
+def test_local_source_discovers_text_files(text_dir):
+    """LocalSource should find .md and .txt alongside .html and .png."""
+    source = LocalSource(str(text_dir))
+    docs = list(source)
+    names = {d.id for d in docs}
+    assert "guide" in names  # .md
+    assert "notes" in names  # .txt
+    assert "page" in names   # .html
+    assert "photo" in names  # .png
+    assert "ignored" not in names  # .csv not supported
+
+
+def test_text_files_have_correct_metadata(text_dir):
+    source = LocalSource(str(text_dir))
+    docs = {d.id: d for d in source}
+
+    # Text files should have type=text and a path (not a URL)
+    assert docs["guide"].metadata["type"] == "text"
+    assert docs["guide"].path is not None
+    assert docs["guide"].url is None
+
+    assert docs["notes"].metadata["type"] == "text"
+    assert docs["notes"].path is not None
+
+
+def test_html_files_have_url(text_dir):
+    source = LocalSource(str(text_dir))
+    docs = {d.id: d for d in source}
+
+    # HTML files should have a file:// URL
+    assert docs["page"].url.startswith("file://")
+    assert docs["page"].metadata["type"] == "web"
+
+
+def test_source_len_includes_text_files(text_dir):
+    source = LocalSource(str(text_dir))
+    assert len(source) == 4  # .md + .txt + .html + .png (not .csv)

--- a/tests/test_pixel_query_path_traversal.py
+++ b/tests/test_pixel_query_path_traversal.py
@@ -1,0 +1,65 @@
+"""Path-traversal hardening tests for eval/lib/pixel_query.py (issues #78, #79).
+
+Tests the sanitization logic directly — verifying that pathlib.Path(x).name
+strips traversal sequences from example_id before it reaches os.path.join.
+Does NOT require a TTF font or actual rendering.
+"""
+
+import os
+import pathlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "example_id,expected_stem",
+    [
+        ("normal_id", "normal_id"),
+        ("../../etc/passwd", "passwd"),
+        ("../evil", "evil"),
+        ("foo/bar/baz", "baz"),
+        ("/absolute/path/id", "id"),
+        ("..%2F..%2Fetc/passwd", "passwd"),  # URL-encoded separators still have /
+        ("....//....//etc/shadow", "shadow"),
+    ],
+)
+def test_safe_id_strips_traversal(example_id, expected_stem):
+    """pathlib.Path(x).name must strip all directory components."""
+    safe_id = pathlib.Path(example_id).name
+    assert safe_id == expected_stem
+
+
+@pytest.mark.parametrize(
+    "example_id",
+    [
+        "../../etc/passwd",
+        "../evil",
+        "foo/bar/baz",
+        "/absolute/path/id",
+        "..\\..\\windows\\system32",
+    ],
+)
+def test_constructed_path_stays_in_output_dir(tmp_path, example_id):
+    """os.path.join with sanitized id must never escape output_dir."""
+    output_dir = str(tmp_path)
+    safe_id = pathlib.Path(example_id).name
+    out_path = os.path.join(output_dir, f"{safe_id}_query.png")
+
+    # Resolve and check containment
+    resolved = pathlib.Path(out_path).resolve()
+    assert str(resolved).startswith(str(tmp_path.resolve()))
+
+
+def test_traversal_does_not_reach_parent(tmp_path):
+    """Even deeply nested traversal must not escape."""
+    evil_ids = [
+        "../" * 10 + "etc/passwd",
+        "..\\..\\..\\windows\\system32\\config",
+    ]
+    for example_id in evil_ids:
+        safe_id = pathlib.Path(example_id).name
+        out_path = os.path.join(str(tmp_path), f"{safe_id}_query.png")
+        resolved = pathlib.Path(out_path).resolve()
+        assert str(resolved).startswith(str(tmp_path.resolve())), (
+            f"{example_id!r} escaped to {resolved}"
+        )


### PR DESCRIPTION
## Summary

Adds a `crawl` source type that automatically discovers all pages on a website and indexes them. No need to manually list URLs.

## Usage

```yaml
source:
  type: crawl
  start_url: https://comprinno.net/
  max_pages: 50
  max_depth: 3
  exclude_patterns:
    - /admin/
    - /login
```

Then `pixelrag index build` will crawl the site, screenshot every discovered page, and build the FAISS index.

## How it works

- BFS crawl from `start_url`, following same-domain `<a href>` links
- Stays on the same domain by default
- Auto-filters non-content URLs (feeds, wp-json, assets, xmlrpc, images, CSS/JS)
- Configurable `max_pages` and `max_depth` limits
- Custom `exclude_patterns` for site-specific filtering
- No new dependencies (stdlib `urllib` + regex)

## Example output (comprinno.net)

```
Crawled comprinno.net: discovered 30 pages (max_pages=30, max_depth=2)
```

Discovered pages include services, newsroom, industry pages — all real content.

## Testing
- All 60 existing tests pass
- Lint clean
- Manually tested on comprinno.net (30 pages discovered)