### PR TITLE
feat(index): add crawl source — auto-discover and index all pages on a site

### DIFF
--- a/index/src/pixelrag_index/config.py
+++ b/index/src/pixelrag_index/config.py
@@ -31,8 +31,8 @@ def load_config(path=None):
 def make_source(config):
     source_config = dict(config.get("source", {}))
     source_type = source_config.pop("type", "local")
-    # Expand ~ in any string values that look like paths
+    # Expand ~ in any string values that look like paths (but not URLs)
     for k, v in source_config.items():
-        if isinstance(v, str) and ("/" in v or "~" in v):
+        if isinstance(v, str) and ("/" in v or "~" in v) and "://" not in v:
             source_config[k] = str(Path(v).expanduser())
     return SOURCES[source_type](**source_config)

--- a/index/src/pixelrag_index/sources/__init__.py
+++ b/index/src/pixelrag_index/sources/__init__.py
@@ -1,4 +1,5 @@
 from .base import Document as Document, Source as Source
+from .crawl import CrawlSource
 from .kiwix import KiwixSource
 from .local import LocalSource
 from .pdf import PDFSource
@@ -9,4 +10,5 @@ SOURCES = {
     "web": WebSource,
     "pdf": PDFSource,
     "local": LocalSource,
+    "crawl": CrawlSource,
 }

--- a/index/src/pixelrag_index/sources/crawl.py
+++ b/index/src/pixelrag_index/sources/crawl.py
@@ -1,0 +1,145 @@
+"""Crawl source — discover and index all pages on a website.
+
+Starts from a URL, follows same-domain links up to a configurable depth/limit,
+and yields each discovered page as a Document for the index pipeline.
+
+Usage in pixelrag.yaml:
+    source:
+      type: crawl
+      start_url: https://example.com/
+      max_pages: 50          # stop after N pages (default: 100)
+      max_depth: 3           # max link-following depth (default: 3)
+      stay_on_domain: true   # don't follow external links (default: true)
+      exclude_patterns:      # skip URLs matching these (optional)
+        - /admin/
+        - /login
+"""
+
+import logging
+import re
+from collections import deque
+from typing import Iterator
+from urllib.parse import urljoin, urlparse
+
+from .base import Document, Source
+
+logger = logging.getLogger(__name__)
+
+
+def _fetch_links(url: str, timeout: int = 10) -> list[str]:
+    """Fetch a page and extract all href links."""
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "PixelRAG-Crawler/1.0"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            html = resp.read().decode("utf-8", errors="replace")
+    except Exception:
+        return []
+
+    # Simple regex link extraction (no dependency on bs4/lxml)
+    return re.findall(r'href=["\']([^"\']+)["\']', html)
+
+
+class CrawlSource(Source):
+    """Crawl a website starting from a URL, discovering pages via links."""
+
+    def __init__(
+        self,
+        start_url: str,
+        max_pages: int = 100,
+        max_depth: int = 3,
+        stay_on_domain: bool = True,
+        exclude_patterns: list[str] | None = None,
+        **kwargs,
+    ):
+        self.start_url = start_url.rstrip("/")
+        self.max_pages = max_pages
+        self.max_depth = max_depth
+        self.stay_on_domain = stay_on_domain
+        self.exclude_patterns = exclude_patterns or []
+        self.domain = urlparse(start_url).netloc
+
+        self._pages: list[str] = []
+        self._crawl()
+
+    def _should_skip(self, url: str) -> bool:
+        """Check if URL should be excluded."""
+        for pattern in self.exclude_patterns:
+            if pattern in url:
+                return True
+        # Skip non-HTML resources
+        path = urlparse(url).path.lower()
+        skip_exts = (".png", ".jpg", ".jpeg", ".gif", ".svg", ".pdf", ".css", ".js", ".ico", ".woff", ".woff2", ".mp4", ".zip")
+        if any(path.endswith(ext) for ext in skip_exts):
+            return True
+        # Skip common non-content paths
+        skip_paths = ("/feed", "/wp-json", "/xmlrpc", "/wp-admin", "/wp-login", "/wp-content", "/trackback", "/comments/feed")
+        if any(s in url for s in skip_paths):
+            return True
+        # Skip query-heavy URLs (likely API/dynamic)
+        if url.count("?") > 0 and url.count("=") > 2:
+            return True
+        # Skip fragments
+        if "#" in url:
+            url = url.split("#")[0]
+        return False
+
+    def _normalize(self, url: str) -> str:
+        """Normalize URL: strip fragment, trailing slash."""
+        url = url.split("#")[0]
+        url = url.rstrip("/")
+        return url
+
+    def _crawl(self):
+        """BFS crawl from start_url."""
+        visited: set[str] = set()
+        queue: deque[tuple[str, int]] = deque([(self.start_url, 0)])
+        visited.add(self._normalize(self.start_url))
+
+        while queue and len(self._pages) < self.max_pages:
+            url, depth = queue.popleft()
+            self._pages.append(url)
+
+            if depth >= self.max_depth:
+                continue
+
+            links = _fetch_links(url)
+            for href in links:
+                # Resolve relative URLs
+                full_url = urljoin(url, href)
+                normalized = self._normalize(full_url)
+
+                # Filter
+                if normalized in visited:
+                    continue
+                if self.stay_on_domain and urlparse(normalized).netloc != self.domain:
+                    continue
+                if self._should_skip(normalized):
+                    continue
+                # Only http/https
+                if not normalized.startswith(("http://", "https://")):
+                    continue
+
+                visited.add(normalized)
+                queue.append((normalized, depth + 1))
+
+        logger.info(
+            "Crawled %s: discovered %d pages (max_pages=%d, max_depth=%d)",
+            self.domain,
+            len(self._pages),
+            self.max_pages,
+            self.max_depth,
+        )
+
+    def __iter__(self) -> Iterator[Document]:
+        for i, url in enumerate(self._pages):
+            slug = urlparse(url).path.strip("/").replace("/", "_") or "index"
+            yield Document(
+                id=f"crawl_{i:04d}_{slug}",
+                url=url,
+                metadata={"type": "web", "depth": 0},
+            )
+
+    def __len__(self) -> int:
+        return len(self._pages)

--- a/index/src/pixelrag_index/sources/crawl.py
+++ b/index/src/pixelrag_index/sources/crawl.py
@@ -31,7 +31,9 @@ def _fetch_links(url: str, timeout: int = 10) -> list[str]:
     import urllib.request
 
     try:
-        req = urllib.request.Request(url, headers={"User-Agent": "PixelRAG-Crawler/1.0"})
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "PixelRAG-Crawler/1.0"}
+        )
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             html = resp.read().decode("utf-8", errors="replace")
     except Exception:
@@ -70,11 +72,34 @@ class CrawlSource(Source):
                 return True
         # Skip non-HTML resources
         path = urlparse(url).path.lower()
-        skip_exts = (".png", ".jpg", ".jpeg", ".gif", ".svg", ".pdf", ".css", ".js", ".ico", ".woff", ".woff2", ".mp4", ".zip")
+        skip_exts = (
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".svg",
+            ".pdf",
+            ".css",
+            ".js",
+            ".ico",
+            ".woff",
+            ".woff2",
+            ".mp4",
+            ".zip",
+        )
         if any(path.endswith(ext) for ext in skip_exts):
             return True
         # Skip common non-content paths
-        skip_paths = ("/feed", "/wp-json", "/xmlrpc", "/wp-admin", "/wp-login", "/wp-content", "/trackback", "/comments/feed")
+        skip_paths = (
+            "/feed",
+            "/wp-json",
+            "/xmlrpc",
+            "/wp-admin",
+            "/wp-login",
+            "/wp-content",
+            "/trackback",
+            "/comments/feed",
+        )
         if any(s in url for s in skip_paths):
             return True
         # Skip query-heavy URLs (likely API/dynamic)

--- a/tests/test_crawl_source.py
+++ b/tests/test_crawl_source.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parents[1] / "index" / "src"))
-from pixelrag_index.sources.crawl import CrawlSource, _fetch_links
+from pixelrag_index.sources.crawl import CrawlSource
 
 
 def _mock_links(url):

--- a/tests/test_crawl_source.py
+++ b/tests/test_crawl_source.py
@@ -35,9 +35,7 @@ def _mock_links(url):
 @pytest.fixture
 def crawl_source():
     with patch("pixelrag_index.sources.crawl._fetch_links", side_effect=_mock_links):
-        yield lambda **kwargs: CrawlSource(
-            start_url="https://example.com/", **kwargs
-        )
+        yield lambda **kwargs: CrawlSource(start_url="https://example.com/", **kwargs)
 
 
 def test_crawl_discovers_links(crawl_source):
@@ -99,6 +97,7 @@ def test_crawl_filters_feeds_and_api(crawl_source):
 
 def test_url_not_mangled_by_config():
     """make_source must not mangle URLs with Path().expanduser()."""
+    pytest.importorskip("yaml")
     from pixelrag_index.config import make_source
 
     config = {

--- a/tests/test_crawl_source.py
+++ b/tests/test_crawl_source.py
@@ -1,0 +1,115 @@
+"""Tests for the crawl source adapter (PR #105)."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "index" / "src"))
+from pixelrag_index.sources.crawl import CrawlSource, _fetch_links
+
+
+def _mock_links(url):
+    """Fake link graph for testing."""
+    graph = {
+        "https://example.com": [
+            "/about",
+            "/services",
+            "/contact",
+            "https://example.com/blog",
+            "https://external.com/other",
+            "/assets/logo.png",
+            "/style.css",
+            "/feed/",
+            "/wp-json/api",
+        ],
+        "https://example.com/about": ["/team", "/about/history"],
+        "https://example.com/services": ["/services/cloud", "/services/ai"],
+        "https://example.com/blog": ["/blog/post-1", "/blog/post-2"],
+        "https://example.com/about/history": ["/about/history/2020"],
+    }
+    return graph.get(url, [])
+
+
+@pytest.fixture
+def crawl_source():
+    with patch("pixelrag_index.sources.crawl._fetch_links", side_effect=_mock_links):
+        yield lambda **kwargs: CrawlSource(
+            start_url="https://example.com/", **kwargs
+        )
+
+
+def test_crawl_discovers_links(crawl_source):
+    """Crawler should discover pages reachable from start_url."""
+    source = crawl_source(max_pages=50, max_depth=3)
+    urls = [doc.url for doc in source]
+    assert "https://example.com" in urls
+    assert "https://example.com/about" in urls
+    assert "https://example.com/services" in urls
+    assert len(urls) > 1
+
+
+def test_crawl_stays_on_domain(crawl_source):
+    """External links should not be followed."""
+    source = crawl_source(max_pages=50, max_depth=3)
+    urls = [doc.url for doc in source]
+    assert not any("external.com" in u for u in urls)
+
+
+def test_crawl_respects_max_pages(crawl_source):
+    """Should stop at max_pages limit."""
+    source = crawl_source(max_pages=3, max_depth=5)
+    assert len(source) == 3
+
+
+def test_crawl_respects_max_depth(crawl_source):
+    """Should not go deeper than max_depth."""
+    source = crawl_source(max_pages=50, max_depth=1)
+    urls = [doc.url for doc in source]
+    # Depth 0 = start, depth 1 = direct links from start
+    # /about/history is depth 2, should NOT be included
+    assert "https://example.com/about/history" not in urls
+    # /about is depth 1, should be included
+    assert "https://example.com/about" in urls
+
+
+def test_crawl_excludes_patterns(crawl_source):
+    """Custom exclude_patterns should filter matching URLs."""
+    source = crawl_source(max_pages=50, max_depth=3, exclude_patterns=["/blog"])
+    urls = [doc.url for doc in source]
+    assert not any("/blog" in u for u in urls)
+
+
+def test_crawl_filters_assets(crawl_source):
+    """Static assets (.png, .css, .js) should be skipped."""
+    source = crawl_source(max_pages=50, max_depth=3)
+    urls = [doc.url for doc in source]
+    assert not any(u.endswith(".png") for u in urls)
+    assert not any(u.endswith(".css") for u in urls)
+
+
+def test_crawl_filters_feeds_and_api(crawl_source):
+    """WordPress feeds and wp-json should be skipped."""
+    source = crawl_source(max_pages=50, max_depth=3)
+    urls = [doc.url for doc in source]
+    assert not any("/feed" in u for u in urls)
+    assert not any("/wp-json" in u for u in urls)
+
+
+def test_url_not_mangled_by_config():
+    """make_source must not mangle URLs with Path().expanduser()."""
+    from pixelrag_index.config import make_source
+
+    config = {
+        "source": {
+            "type": "crawl",
+            "start_url": "https://comprinno.net/",
+            "max_pages": 1,
+            "max_depth": 0,
+        }
+    }
+    with patch("pixelrag_index.sources.crawl._fetch_links", return_value=[]):
+        source = make_source(config)
+    assert source.start_url == "https://comprinno.net"
+    assert source.domain == "comprinno.net"


### PR DESCRIPTION
## Summary

Adds a `crawl` source type that automatically discovers all pages on a website via BFS link-following.

## Usage

```yaml
source:
  type: crawl
  start_url: https://comprinno.net/
  max_pages: 150
  max_depth: 3
  exclude_patterns:
    - "?p="
    - "/page/"
    - "/2025/"
    - "/2026/"

embed:
  model: Qwen/Qwen3-VL-Embedding-2B
  device: auto

output: ./comprinno_index
```

Then:
```bash
pixelrag index build
```

This crawls comprinno.net (~150 pages), screenshots every page, embeds all chunks with Qwen3-VL, and builds a searchable FAISS index — fully automated.

## Changes (from main only)

- **New file:** `index/src/pixelrag_index/sources/crawl.py` — BFS crawler with domain filtering
- **`sources/__init__.py`:** Register `CrawlSource` in SOURCES dict
- **`config.py`:** Fix bug where `Path().expanduser()` mangled URLs containing `://`

## Features
- BFS traversal with `max_pages` and `max_depth` limits
- Same-domain only by default (`stay_on_domain: true`)
- Auto-filters junk URLs: feeds, wp-json, wp-content, assets, xmlrpc
- Custom `exclude_patterns` list for site-specific filtering
- No new dependencies (stdlib `urllib` + `re` only)

## Tested on comprinno.net
- Discovers 150+ real content pages (services, case studies, blogs)
- Filters out WordPress shortlinks (`?p=`), pagination, date archives
- All 23 existing tests pass
- Lint clean