### PR TITLE
fix(cli): accept auto/mps devices in index build, with CI-safe test

### DIFF
--- a/index/src/pixelrag_index/pipelines.py
+++ b/index/src/pixelrag_index/pipelines.py
@@ -217,7 +217,10 @@ def main():
     )
     parser.add_argument("--output", "-o", default=None, help="Output directory")
     parser.add_argument(
-        "--device", default=None, choices=["cpu", "cuda"], help="Embedding device"
+        "--device",
+        default=None,
+        choices=["auto", "cpu", "mps", "cuda"],
+        help="Embedding device (default: from config; auto-detects cuda/mps/cpu)",
     )
     parser.add_argument(
         "--limit", "-n", type=int, default=None, help="Max documents to process"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,17 @@ def test_pixelrag_unknown_stage_errors():
     assert "unknown" in (r.stdout + r.stderr).lower()
 
 
+def test_index_build_device_choices():
+    """CLI must offer auto/mps/cuda/cpu device choices."""
+    r = _run("pixelrag", "index", "build", "--help")
+    if r.returncode != 0 and "not installed" in (r.stdout + r.stderr):
+        import pytest
+
+        pytest.skip("index stage not installed")
+    assert r.returncode == 0
+    assert "{auto,cpu,mps,cuda}" in r.stdout
+
+
 def test_light_imports():
     # Core install must import without torch.
     import pixelrag  # noqa: F401


### PR DESCRIPTION
## Problem

`pixelrag index build --device auto` fails because argparse only allows `cpu` and `cuda`. PR #73 fixed the choices but its test fails in CI because `pixelrag index build --help` imports `config.py` → `yaml` which isn't installed in core-only CI.

## Fix

1. Add `auto`, `mps` to `--device` choices
2. Test gracefully skips when the index stage isn't installed:
   ```python
   if r.returncode != 0 and "not installed" in (r.stdout + r.stderr):
       pytest.skip("index stage not installed")
   ```

Supersedes #73 (same feature fix + working CI).