### PR TITLE
fix(deps): move tqdm, pyyaml, numpy from heavy extras into core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,13 @@ dependencies = [
     "pyturbojpeg>=2.2.0",
     "cef-capi-py>=131.3.5",
     "anthropic>=0.102.0",
+    # Light, pure-Python utilities the umbrella CLI and the non-torch stage code
+    # (chunk / config parsing / progress bars) import at module load. Kept in core
+    # — not the heavy `embed`/`index` extras — so `pixelrag chunk`, `pixelrag index`,
+    # and the torch-free test suite import cleanly without pulling torch/faiss.
+    "numpy>=1.26.0",
+    "pyyaml>=6.0",
+    "tqdm>=4.60.0",
 ]
 
 [project.optional-dependencies]
@@ -29,20 +36,17 @@ embed = [
     "torchvision>=0.24.0",
     "transformers>=4.57.0",
     "faiss-cpu>=1.9.0",
-    "numpy>=1.26.0",
-    "tqdm>=4.60.0",
 ]
 serve = [
     "fastapi>=0.115.0",
     "uvicorn>=0.30.0",
-    "numpy>=1.26.0",
     "faiss-cpu>=1.9.0",
     "transformers>=4.57.0",
     "torch>=2.9.0",
     "qwen-vl-utils",
     "pydantic>=2.0.0",
 ]
-index = ["pixelrag[embed]", "pyyaml>=6.0", "markdown>=3.4"]
+index = ["pixelrag[embed]", "markdown>=3.4"]
 all = ["pixelrag[embed,serve,index]"]
 gpu = ["faiss-gpu-cu12>=1.13.2; sys_platform == 'linux'"]
 playwright = ["playwright>=1.40.0"]
@@ -52,7 +56,6 @@ distributed = ["boto3>=1.42.0"]
 eval = [
     "pandas>=2.0",
     "Pillow>=10.0",
-    "tqdm>=4.60",
     "trafilatura>=1.6",
     "openai>=1.0",
     "aiohttp>=3.9",

--- a/uv.lock
+++ b/uv.lock
@@ -1417,9 +1417,12 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "cef-capi-py", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pymupdf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyturbojpeg", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "websockets", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
@@ -1428,16 +1431,13 @@ all = [
     { name = "faiss-cpu", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "fastapi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "qwen-vl-utils", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "torch", version = "2.9.1+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform == 'linux'" },
     { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
     { name = "torchvision", version = "0.24.1", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.24.1+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "transformers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "uvicorn", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
@@ -1449,13 +1449,11 @@ distributed = [
 ]
 embed = [
     { name = "faiss-cpu", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "torch", version = "2.9.1+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform == 'linux'" },
     { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
     { name = "torchvision", version = "0.24.1", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.24.1+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "transformers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 eval = [
@@ -1465,7 +1463,6 @@ eval = [
     { name = "openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pandas", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "trafilatura", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 gpu = [
@@ -1474,14 +1471,11 @@ gpu = [
 index = [
     { name = "faiss-cpu", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "torch", version = "2.9.1+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform == 'linux'" },
     { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
     { name = "torchvision", version = "0.24.1", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.24.1+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "transformers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 kiwix = [
@@ -1496,7 +1490,6 @@ playwright = [
 serve = [
     { name = "faiss-cpu", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "fastapi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "qwen-vl-utils", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "torch", version = "2.9.1+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform == 'linux'" },
@@ -1519,8 +1512,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'eval'", specifier = ">=0.20" },
     { name = "libzim", marker = "extra == 'kiwix'", specifier = ">=3.6.0" },
     { name = "markdown", marker = "extra == 'index'", specifier = ">=3.4" },
-    { name = "numpy", marker = "extra == 'embed'", specifier = ">=1.26.0" },
-    { name = "numpy", marker = "extra == 'serve'", specifier = ">=1.26.0" },
+    { name = "numpy", specifier = ">=1.26.0" },
     { name = "openai", marker = "extra == 'eval'", specifier = ">=1.0" },
     { name = "pandas", marker = "extra == 'eval'", specifier = ">=2.0" },
     { name = "pdf2image", marker = "extra == 'pdf'", specifier = ">=1.16.0" },
@@ -1533,7 +1525,7 @@ requires-dist = [
     { name = "pymupdf", specifier = ">=1.27.2.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pyturbojpeg", specifier = ">=2.2.0" },
-    { name = "pyyaml", marker = "extra == 'index'", specifier = ">=6.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "qwen-vl-utils", marker = "extra == 'serve'" },
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'embed'", specifier = ">=2.9.0", index = "https://download.pytorch.org/whl/cu129" },
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'serve'", specifier = ">=2.9.0", index = "https://download.pytorch.org/whl/cu129" },
@@ -1541,8 +1533,7 @@ requires-dist = [
     { name = "torch", marker = "sys_platform != 'linux' and extra == 'serve'", specifier = ">=2.9.0" },
     { name = "torchvision", marker = "sys_platform == 'linux' and extra == 'embed'", specifier = ">=0.24.0", index = "https://download.pytorch.org/whl/cu129" },
     { name = "torchvision", marker = "sys_platform != 'linux' and extra == 'embed'", specifier = ">=0.24.0" },
-    { name = "tqdm", marker = "extra == 'embed'", specifier = ">=4.60.0" },
-    { name = "tqdm", marker = "extra == 'eval'", specifier = ">=4.60" },
+    { name = "tqdm", specifier = ">=4.60.0" },
     { name = "trafilatura", marker = "extra == 'eval'", specifier = ">=1.6" },
     { name = "transformers", marker = "extra == 'embed'", specifier = ">=4.57.0" },
     { name = "transformers", marker = "extra == 'serve'", specifier = ">=4.57.0" },


### PR DESCRIPTION
## Problem

Several PRs fail CI's `Tests` job at **import/collection time** with `ModuleNotFoundError` (`tqdm`, `yaml`, `numpy`) — not on any assertion. The suite is deliberately torch-free (no test imports `torch`/`faiss`/`transformers`), and it runs on `uv sync --extra dev` (core + pytest only).

Root cause: three **light, pure-Python** utilities are gated behind the **heavy** `embed`/`index` extras, even though modules that are meant to run without torch import them at module load:

- `embed/chunk.py` — pure image slicing (stdlib + PIL), uses `tqdm`
- `index/config.py` — config parsing, uses `yaml`
- `embed/embed.py` — **deliberately lazy-imports `torch`** inside functions, but imports `numpy`/`tqdm` at the top

So `pixelrag chunk` / `pixelrag index --help` and these tests can't import on a core-only install without dragging in torch/faiss.

## Fix

Move `tqdm`, `pyyaml`, `numpy` into core `dependencies`; drop the now-redundant copies from the `embed`/`serve`/`index`/`eval` extras. No CI changes, **no `pytest.skip` workarounds** — the light stages simply become importable light again.

"Core stays light — no torch" still holds: these are not torch/GPU/heavy-ML deps. `uv lock --locked` confirms the lock is consistent (no re-resolution; no version changes — pure regrouping).

## Unblocks (once merged, these go genuinely green — no skips)

- #73 — `--device auto/mps`: its `index --help` test needs `yaml`, now in core
- #83 — article_id manifests: its test imports `embed.embed` (numpy/tqdm), now in core
- #108 — chunk progress bar: adds `tqdm` import to `chunk.py`, now in core