### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixelrag"
-version = "0.3.0"
+version = "0.4.0"
 description = "Visual Retrieval-Augmented Generation — render, embed, index, search"
 requires-python = ">=3.12"
 authors = [{ name = "Zhifei Li", email = "andylizf@outlook.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1418,7 +1418,7 @@ wheels = [
 
 [[package]]
 name = "pixelrag"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },


### PR DESCRIPTION
Version bump for the 0.4.0 release (see the release notes on the tag). No code changes.