### PR TITLE
fix(serve): bound n_docs to prevent unbounded-search OOM/DoS

### DIFF
--- a/serve/src/pixelrag_serve/api.py
+++ b/serve/src/pixelrag_serve/api.py
@@ -50,7 +50,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, Response
 from PIL import Image
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 _request_id_ctx: contextvars.ContextVar[str] = contextvars.ContextVar(
     "request_id",
@@ -141,7 +141,9 @@ class Query(BaseModel):
 
 class SearchRequest(BaseModel):
     queries: list[Query]
-    n_docs: int = 10
+    # Bounded: fetch_k = n_docs * 10 feeds FAISS search k, so an unbounded value
+    # is a trivial OOM/DoS on the public endpoint. Largest real caller uses 10.
+    n_docs: int = Field(default=10, ge=1, le=1000)
     nprobe: int | None = None  # override default nprobe
     min_tile_height: int | None = None  # filter out small/blank chunks
     instruction: str | None = None  # override query embedding instruction


### PR DESCRIPTION
## Problem

`SearchRequest.n_docs` had no bound (`n_docs: int = 10`), and downstream
`fetch_k = req.n_docs * 10` feeds FAISS's search `k`. A request like
`{"queries": [...], "n_docs": 100000000}` forces a huge result-buffer allocation on
the public `/search` endpoint — a trivial OOM/DoS. Zero and negative values were also
accepted.

## Fix

Constrain via pydantic: `n_docs: int = Field(default=10, ge=1, le=1000)`. The largest
real caller (README examples, web app, eval harness) uses `10`, so the `1000` cap is
generous. One line, declarative, no behavior change for valid requests; out-of-range
values now return a 422 instead of degrading the service.
