### PR TITLE
fix(index): accept a single file as a source path

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,11 @@ pixelrag serve --index-dir ./my_index --port 30001
 
 No GPU required — runs on macOS (Apple Silicon) or any machine with Python 3.10+.
 
+PDF rendering needs the `pdf` extra and poppler (`brew install poppler`, or
+`apt-get install poppler-utils` on Debian/Ubuntu).
+
 ```bash
-pip install 'pixelrag[index]'
+pip install 'pixelrag[index,pdf]'
 
 # 1. Grab a sample PDF (or use your own)
 curl -L -o paper.pdf https://raw.githubusercontent.com/StarTrail-org/PixelRAG/main/assets/pixelrag-paper.pdf

--- a/index/src/pixelrag_index/sources/local.py
+++ b/index/src/pixelrag_index/sources/local.py
@@ -1,4 +1,4 @@
-"""Local directory source — auto-detect file types."""
+"""Local source — a single file or a directory tree; auto-detect file types."""
 
 from pathlib import Path
 from typing import Iterator
@@ -20,10 +20,13 @@ EXTENSIONS = {
 class LocalSource(Source):
     def __init__(self, path: str, **kwargs):
         self.path = Path(path)
+        # A path pointing straight at a document is a single-item source; rglob
+        # on a file yields nothing, so branch before walking.
+        candidates = (
+            [self.path] if self.path.is_file() else sorted(self.path.rglob("*"))
+        )
         self._files = [
-            f
-            for f in sorted(self.path.rglob("*"))
-            if f.is_file() and f.suffix.lower() in EXTENSIONS
+            f for f in candidates if f.is_file() and f.suffix.lower() in EXTENSIONS
         ]
 
     def __iter__(self) -> Iterator[Document]:

--- a/index/src/pixelrag_index/sources/pdf.py
+++ b/index/src/pixelrag_index/sources/pdf.py
@@ -1,4 +1,4 @@
-"""PDF directory source."""
+"""PDF source — a single .pdf file or a directory tree of them."""
 
 from pathlib import Path
 from typing import Iterator
@@ -9,7 +9,13 @@ from .base import Document, Source
 class PDFSource(Source):
     def __init__(self, path: str, **kwargs):
         self.path = Path(path)
-        self._files = sorted(self.path.glob("**/*.pdf"))
+        # A path pointing straight at a .pdf is a single-item source; the glob
+        # below only ever matches inside a directory.
+        self._files = (
+            [self.path]
+            if self.path.is_file() and self.path.suffix.lower() == ".pdf"
+            else sorted(self.path.glob("**/*.pdf"))
+        )
 
     def __iter__(self) -> Iterator[Document]:
         for pdf in self._files:

--- a/tests/test_source_single_file.py
+++ b/tests/test_source_single_file.py
@@ -1,0 +1,50 @@
+"""A source path may point straight at a document, not just a directory.
+
+`pixelrag index build --source ./paper.pdf` is the form the README documents,
+but both adapters used to walk the path as a directory — which silently
+yielded zero documents and failed several stages later at index build.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "index" / "src"))
+from pixelrag_index.sources.local import LocalSource
+from pixelrag_index.sources.pdf import PDFSource
+
+
+@pytest.fixture
+def docs_dir(tmp_path):
+    (tmp_path / "paper.pdf").write_bytes(b"%PDF-1.4\n")
+    (tmp_path / "notes.md").write_text("# Notes")
+    (tmp_path / "ignored.csv").write_text("a,b,c")
+    nested = tmp_path / "sub"
+    nested.mkdir()
+    (nested / "deep.pdf").write_bytes(b"%PDF-1.4\n")
+    return tmp_path
+
+
+def test_pdf_source_accepts_a_single_file(docs_dir):
+    source = PDFSource(str(docs_dir / "paper.pdf"))
+    assert [d.id for d in source] == ["paper"]
+    assert len(source) == 1
+
+
+def test_local_source_accepts_a_single_file(docs_dir):
+    source = LocalSource(str(docs_dir / "notes.md"))
+    docs = list(source)
+    assert [d.id for d in docs] == ["notes"]
+    assert docs[0].metadata["type"] == "text"
+
+
+def test_local_source_single_file_still_filters_by_extension(docs_dir):
+    """An unsupported suffix yields nothing, matching directory behaviour."""
+    assert len(LocalSource(str(docs_dir / "ignored.csv"))) == 0
+
+
+def test_directory_traversal_is_unchanged(docs_dir):
+    """The directory path must keep recursing into sub-directories."""
+    assert {d.id for d in PDFSource(str(docs_dir))} == {"paper", "deep"}
+    assert {d.id for d in LocalSource(str(docs_dir))} == {"paper", "notes", "deep"}


### PR DESCRIPTION
## Problem

Following the README's own PDF quickstart end to end fails:

```yaml
source:
  type: local
  path: ./paper.pdf
```

`LocalSource` discovers files with `rglob("*")` and `PDFSource` with `glob("**/*.pdf")`. Both return nothing when the path points at a **file** rather than a directory, so the source yields zero documents. Nothing errors at that point — the run continues through render, chunk and embed as no-ops and dies four stages later:

```
Stage 1/4: Rendering 0 documents to tiles...
Stage 4/4: Building FAISS index (0 vectors, nlist=1)...
No shard files found!
subprocess.CalledProcessError: ... returned non-zero exit status 1
```

The failure message points at the index builder, several stages away from the actual cause.

Reproducer against the repo's own asset:

```python
>>> len(PDFSource("assets/pixelrag-paper.pdf")._files)
0
>>> len(PDFSource("assets")._files)
1
```

## Fix

Branch on `is_file()` in both adapters, so a path pointing straight at a document is a single-item source. Directory traversal is untouched, and the single-file path keeps the same extension filtering the directory path applies.

## Also

The PDF quickstart installs `pixelrag[index]`, which cannot render a PDF — `pdf2image` lives in the `pdf` extra and needs poppler. Added to the install line and a short note.

## Tests

Four tests in `tests/test_source_single_file.py`, including one pinning the existing directory-traversal behaviour (recursive, both adapters) so this stays a widening and not a change.

## Verification

On macOS (Apple Silicon, MPS), `pixelrag index build` against `assets/pixelrag-paper.pdf`:

| Source path | Before | After |
|---|---|---|
| `assets/` (directory) | 35 vectors | 35 vectors |
| `assets/pixelrag-paper.pdf` (file) | **0 documents, crash** | 35 vectors |

Both indexes serve and return the expected tile — querying *"Overview of PixelRAG and the diagram"* returns page 2 (the Figure 1 overview), matching the README's stated expectation.

`pytest tests/` → 86 passed, 6 skipped. `ruff check` and `ruff format --check` clean.

## Note for reviewers

`LocalSource` also feeds the `web`/`kiwix` paths downstream. The existing suite only covered directory inputs, so I could not verify against a usage that relies on a file path yielding zero documents — worth a look if any exists.