### PR TITLE
fix(serve): accept --device mps for Apple Silicon

### DIFF
--- a/serve/src/pixelrag_serve/api.py
+++ b/serve/src/pixelrag_serve/api.py
@@ -849,9 +849,9 @@ def main():
     parser.add_argument("--model", default="Qwen/Qwen3-VL-Embedding-2B")
     parser.add_argument(
         "--device",
-        choices=["cpu", "cuda"],
+        choices=["cpu", "cuda", "mps"],
         default="cpu",
-        help="Device to run inference on: cpu (default) or cuda",
+        help="Device to run inference on: cpu (default), cuda, or mps",
     )
     parser.add_argument(
         "--peft-adapter",


### PR DESCRIPTION
## Problem

The index build CLI accepts `--device mps` since #73 / #109, but the serve CLI was left behind: `serve/src/pixelrag_serve/api.py` still has `choices=["cpu", "cuda"]`, so on Apple Silicon `pixelrag serve --device mps` fails at argument parsing:

```
pixelrag serve: error: argument --device: invalid choice: 'mps' (choose from 'cpu', 'cuda')
```

The downstream logic already handles non-cpu devices correctly (`dtype = torch.float32 if device == "cpu" else torch.bfloat16`), so the argparse whitelist is the only blocker.

## Fix

Add `"mps"` to the `--device` choices and update the help text. No other changes needed.

## Testing

- `uvx ruff check .` passes
- `pytest tests/` — 87 passed; 5 pre-existing failures in `test_department_filter.py` reproduce identically on unmodified `main` (unrelated to this change)
- Verified on real hardware: M3 MacBook Air (8 GB RAM, macOS 14.4). With this patch, `pixelrag serve --device mps` loads Qwen3-VL-Embedding-2B in bfloat16 (~4.3 GB), and search over a prebuilt FAISS index responds in 0.2–1.2 s per query after warmup. Retrieval scores match CPU/float32 results from the same index within ±0.001.