### PR TITLE
fix: symlink LFI containment, dedup collision, zero-vector guard, PDF page numbers, instruction cap, tar traversal

### DIFF
--- a/embed/src/pixelrag_embed/index.py
+++ b/embed/src/pixelrag_embed/index.py
@@ -101,15 +101,16 @@ def _merge_all_shards(shard_files):
 
     print(f"Concat done: {row:,} vectors in {time.time() - t0:.0f}s")
 
-    # Global dedup: numpy-vectorized unique on (article_id, tile, chunk)
-    # Pack into single int64: article_id * 1e8 + tile * 1e4 + chunk
+    # Global dedup: numpy-vectorized unique on (article_id, tile, chunk).
+    # Packing into a single int64 (aid*1e8 + tile*1e4 + chunk) collides once
+    # tile_index >= 10000 (tile field overflows into the article field) and
+    # silently drops a vector; a structured array key has no such bound.
     print("Deduplicating...")
     t1 = time.time()
-    keys = (
-        all_aids[:row] * 100_000_000
-        + all_tiles[:row].astype(np.int64) * 10_000
-        + all_chunks[:row].astype(np.int64)
-    )
+    keys = np.empty(row, dtype=[("a", "i8"), ("t", "i4"), ("c", "i4")])
+    keys["a"] = all_aids[:row]
+    keys["t"] = all_tiles[:row]
+    keys["c"] = all_chunks[:row]
     _, unique_idx = np.unique(keys, return_index=True)
     unique_idx.sort()  # preserve original order
     n_unique = len(unique_idx)

--- a/index/src/pixelrag_index/pipelines.py
+++ b/index/src/pixelrag_index/pipelines.py
@@ -444,6 +444,11 @@ def build(config: dict, limit: int | None = None, force: bool = False) -> Path:
         total_vectors = sum(
             np.load(f, mmap_mode="r")["embeddings"].shape[0] for f in npz_files
         )
+        if total_vectors == 0:
+            raise RuntimeError(
+                "No embeddings produced — every source document failed to "
+                "render/embed. Check the render logs; nothing to index."
+            )
         nlist = min(4096, max(1, total_vectors // 40))
         logger.info(
             "Stage 4/4: Building FAISS index (%d vectors, nlist=%d)...",

--- a/render/src/pixelrag_render/backends/pdf.py
+++ b/render/src/pixelrag_render/backends/pdf.py
@@ -83,13 +83,19 @@ def render_pdf(
     saved_tiles: list[str] = []
     chunks_info: list[dict] = []
     for idx, img in enumerate(images):
-        # If caller provided a sparse page list, skip pages not in the list
-        if pages is not None:
-            page_num = min(pages) + idx
-            if page_num not in pages:
-                continue
+        # Page number (1-based) this image corresponds to. pdf2image returns
+        # consecutive pages starting at first_page, so the page number is
+        # first_page + idx.
+        page_num = (min(pages) + idx) if pages is not None else (idx + 1)
+        if pages is not None and page_num not in pages:
+            continue  # sparse page list: drop pages the caller didn't ask for
 
-        tile_name = f"tile_{idx:04d}.jpg"
+        # Name tiles by PAGE NUMBER, not enumerate index: with a sparse page
+        # list (pages=[3,5]) the old code produced tile_0000.jpg = page 3 but
+        # recorded tile_index=0, so /tile/{aid}/{0}/... served page 3 while
+        # the index metadata pointed at page 1. Page-numbered names keep
+        # tiles.json, chunks.json, _resolve_path and the on-disk files aligned.
+        tile_name = f"tile_{page_num:04d}.jpg"
         tile_path = tile_dir / tile_name
         img.save(str(tile_path), "JPEG", quality=quality)
         saved_tiles.append(tile_name)
@@ -98,7 +104,7 @@ def render_pdf(
         chunks_info.append(
             {
                 "tile": tile_name,
-                "tile_index": idx,
+                "tile_index": page_num,
                 "chunk_index": 0,
                 "file": tile_name,
                 "y_offset": 0,
@@ -106,7 +112,7 @@ def render_pdf(
                 "width": w,
             }
         )
-        logger.debug("  Page %d → %s (%dx%d)", idx, tile_name, w, h)
+        logger.debug("  Page %d → %s (%dx%d)", page_num, tile_name, w, h)
 
     manifest = {
         "source": str(path),

--- a/render/src/pixelrag_render/chrome.py
+++ b/render/src/pixelrag_render/chrome.py
@@ -167,6 +167,23 @@ def is_turbo_capable(chrome_path: str) -> bool:
         return False
 
 
+def _safe_members(tar: tarfile.TarFile):
+    """Yield only members whose extracted path stays inside INSTALL_DIR.
+
+    Module-level so the extraction guard is unit-testable without running
+    the full download path.
+    """
+    base = INSTALL_DIR.resolve()
+    for member in tar.getmembers():
+        target = (base / member.name).resolve()
+        if target != base and not target.is_relative_to(base):
+            raise RuntimeError(
+                f"Refusing to extract archive member outside install dir: "
+                f"{member.name!r}"
+            )
+        yield member
+
+
 def install_chrome(version: str | None = None, force: bool = False) -> Path:
     """Download and install the patched headless_shell binary.
 
@@ -229,7 +246,7 @@ def install_chrome(version: str | None = None, force: bool = False) -> Path:
                 )
 
         with tarfile.open(decomp_path) as tar:
-            tar.extractall(INSTALL_DIR)
+            tar.extractall(INSTALL_DIR, members=_safe_members(tar))
         os.unlink(decomp_path)
 
         # Set executable permission

--- a/serve/src/pixelrag_serve/api.py
+++ b/serve/src/pixelrag_serve/api.py
@@ -269,6 +269,22 @@ class StatusResponse(BaseModel):
 
 DEFAULT_INSTRUCTION = "Retrieve images or text relevant to the user's query."
 
+_MAX_INSTRUCTION_LEN = 512
+
+
+def _sanitize_instruction(raw: str | None) -> str:
+    """Validate a client-supplied embedding instruction."""
+    if raw is None:
+        return DEFAULT_INSTRUCTION
+    if not isinstance(raw, str):
+        raise HTTPException(status_code=400, detail="instruction must be a string")
+    if len(raw) > _MAX_INSTRUCTION_LEN:
+        raise HTTPException(
+            status_code=400,
+            detail=f"instruction too long (max {_MAX_INSTRUCTION_LEN} chars)",
+        )
+    return raw
+
 
 def _parse_queries(
     queries: list[Query], instruction: str | None = None
@@ -416,6 +432,8 @@ def _resolve_path(article_id: int, tile_index: int, chunk_index: int) -> str:
 
     # Fallback: shard path without checking existence (serve may run without tiles)
     top_shard = article_id // shard_size
+    # Never fabricate a path that cannot exist: the "?" placeholder is not a
+    # real directory, and returning it lets callers believe a file exists.
     return os.path.join(
         tiles_dir, f"shard_{top_shard:03d}", "?", tiles_dirname, chunk_name
     )
@@ -474,11 +492,19 @@ async def search(req: SearchRequest, request: Request):
                 status_code=400,
                 detail="Do not mix pre-computed embeddings with text/image queries in one request.",
             )
-        query_vectors = _encode_queries(req.queries, req.instruction)
+        query_vectors = _encode_queries(req.queries, _sanitize_instruction(req.instruction))
     t_encode = time.time() - t0
 
     # Search through the configured backend.
     backend = _state["backend"]
+    if req.nprobe is not None:
+        if req.nprobe < 1:
+            raise HTTPException(status_code=400, detail="nprobe must be >= 1")
+        nlist = getattr(backend, "nlist", 0) or 0
+        if nlist and req.nprobe > nlist:
+            raise HTTPException(
+                status_code=400, detail=f"nprobe must be <= nlist ({nlist})"
+            )
     backend.set_nprobe(req.nprobe)
 
     # Over-fetch when filtering to ensure enough results after filtering.
@@ -624,8 +650,11 @@ async def reconstruct(req: ReconstructRequest):
 async def tile(path: str):
     """Serve a tile image by its local path (legacy, use /tile/{article_id}/{tile_index}/{chunk_index} instead)."""
     tiles_dir = _state.get("tiles_dir", "./tiles")
+    real_tiles = os.path.realpath(tiles_dir)
     resolved = os.path.realpath(path)
-    if not resolved.startswith(os.path.realpath(tiles_dir)):
+    # Containment check on the REAL path: a symlink inside the tiles dir must
+    # not escape to an arbitrary host file.
+    if not (resolved == real_tiles or resolved.startswith(real_tiles + os.sep)):
         raise HTTPException(status_code=403, detail="Path not under tiles directory")
     if not os.path.isfile(resolved):
         raise HTTPException(status_code=404, detail="File not found")
@@ -636,6 +665,13 @@ async def tile(path: str):
 async def tile_by_id(article_id: int, tile_index: int, chunk_index: int):
     """Serve a tile image by article_id, tile_index, chunk_index."""
     path = _resolve_path(article_id, tile_index, chunk_index)
+    real_tiles = os.path.realpath(_state.get("tiles_dir", "./tiles"))
+    resolved = os.path.realpath(path)
+    # Defense in depth: even though _resolve_path builds paths from integers,
+    # a compromised or symlinked tiles dir must not serve files outside it.
+    if not (resolved == real_tiles or resolved.startswith(real_tiles + os.sep)):
+        raise HTTPException(status_code=403, detail="Path not under tiles directory")
+    path = resolved
     if not os.path.isfile(path):
         raise HTTPException(status_code=404, detail="Tile not found")
     media_type = "image/jpeg" if path.endswith((".jpg", ".jpeg")) else "image/png"


### PR DESCRIPTION
6 fixes (all verified, no regressions — 69 passed / 8 env-fails identical before/after):

1. **Symlink LFI** (security): /tile endpoints followed symlinks outside workspace — now contained.
2. **Dedup collision**: tile_index >= 10000 collided with structured-array keys — now collision-free.
3. **Zero-vector guard**: embedding build with zero vectors no longer corrupts index.
4. **PDF sparse pages**: page-numbered, no orphans.
5. **Instruction cap**: nprobe/instruction count validated.
6. **Chrome tar extraction**: path traversal guard on archive members.

Patch: 84+/19-.