### PR TITLE
fix(render): bound web-font readiness wait

### DIFF
--- a/render/src/pixelrag_render/backends/cdp.py
+++ b/render/src/pixelrag_render/backends/cdp.py
@@ -185,6 +185,9 @@ async def _cdp_send(ws, msg_id_ref: list, method: str, params: dict | None = Non
 # before giving up and capturing whatever is there. Keeps a hanging page from
 # stalling a worker.
 LOAD_TIMEOUT_MS = 12_000
+# Web-font loads are allowed a short grace period, but must not stall a render:
+# a server can leave a font response open indefinitely.
+FONT_TIMEOUT_MS = 2_000
 # The network is considered idle once at most NET_IDLE_MAX_INFLIGHT requests
 # have been in flight for NET_QUIET_MS (Puppeteer's "networkidle2" semantics).
 # Tolerating 2 in-flight requests is what makes this usable on arbitrary web
@@ -352,7 +355,10 @@ def _readiness_expr() -> str:
             const t = setTimeout(res, {LOAD_TIMEOUT_MS});
             window.addEventListener('load', () => {{ clearTimeout(t); res(); }}, {{ once: true }});
         }});
-        await document.fonts.ready;
+        await Promise.race([
+            document.fonts.ready,
+            new Promise(r => setTimeout(r, {FONT_TIMEOUT_MS})),
+        ]);
         // Let layout settle over two frames — but cap it: requestAnimationFrame
         // never ticks in some headless modes (e.g. google-chrome --headless=new
         // with no compositor frames scheduled), where awaiting rAF would hang.

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -7,8 +7,15 @@ to end rather than mocked.
 """
 
 import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
+import pytest
 from pixelrag_render import render_file
 
 
@@ -63,3 +70,89 @@ def test_page_taller_than_a_viewport_bounded_body_is_fully_tiled(tmp_path):
         "content below the fold was never measured"
     )
     assert len(tiles) > 1, f"expected multiple tiles, got {[t.name for t in tiles]}"
+
+
+def test_hanging_web_font_does_not_stall_render(tmp_path):
+    """A font request that never finishes must not block the CDP renderer."""
+    release_font = threading.Event()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/hanging.woff2":
+                self.send_response(200)
+                self.send_header("Content-Type", "font/woff2")
+                self.send_header("Content-Length", "1000000")
+                self.end_headers()
+                self.wfile.write(b"\0")
+                self.wfile.flush()
+                release_font.wait(timeout=60)
+                return
+
+            body = "".join(f"<p>line {i:03d}</p>" for i in range(200))
+            html = f"""<!doctype html>
+                <html><head><script>
+                window.addEventListener("load", () => {{
+                    const style = document.createElement("style");
+                    style.textContent = `@font-face {{
+                        font-family: HangingFont;
+                        src: url('/hanging.woff2') format('woff2');
+                    }} body {{ font-family: HangingFont; }}`;
+                    document.head.appendChild(style);
+                    document.fonts.load("16px HangingFont");
+                }});
+                </script></head><body>{body}</body></html>"""
+            payload = html.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, _format, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    output = tmp_path / "tiles"
+    url = f"http://127.0.0.1:{server.server_port}/"
+    script = (
+        "from pixelrag_render import render_url; import sys; "
+        "render_url(sys.argv[1], sys.argv[2], tile_height=300, "
+        "viewport_width=400, workers=1, turbo=False)"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script, url, str(output)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+
+    try:
+        try:
+            stdout, stderr = proc.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            os.killpg(proc.pid, signal.SIGTERM)
+            try:
+                stdout, stderr = proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(proc.pid, signal.SIGKILL)
+                stdout, stderr = proc.communicate()
+            pytest.fail(
+                "render remained blocked by document.fonts.ready for 30 seconds\n"
+                f"stdout:\n{stdout[-2000:]}\nstderr:\n{stderr[-2000:]}"
+            )
+    finally:
+        release_font.set()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert proc.returncode == 0, f"stdout:\n{stdout}\nstderr:\n{stderr}"
+    manifests = list(output.rglob("tiles.json"))
+    assert len(manifests) == 1
+    manifest = json.loads(manifests[0].read_text())
+    assert manifest["page_height"] > 300
+    assert len(manifest["tiles"]) > 1


### PR DESCRIPTION
## Summary

- Fixes: When a page starts loading a web font after the load event and its response never completes, the CDP renderer never produces a page height or any tiles.
- Root cause: The in-page readiness expression awaits document.fonts.ready without a timeout, so an incomplete font response leaves Runtime.evaluate unresolved even though the neighboring load and layout waits are bounded.

The font-readiness wait now has a two-second upper bound before the existing
layout-stabilization step continues.

Fixes #133

## Regression evidence

- Before: `uv run --no-sync pytest tests/test_render.py -q -k hanging_web_font` exited `1`

- After: `uv run --no-sync pytest tests/test_render.py -q -k hanging_web_font` exited `0`

## Verification

- `uv run --no-sync pytest tests/ -q`
- `uvx ruff check .`
- `uvx ruff format --check .`

## Scope

- 2 files changed, +100 / -1 lines
