### PR TITLE
chore(release): fail a release whose tag disagrees with pyproject version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,20 @@ jobs:
         with:
           version: "latest"
 
+      # Guard against tag/version drift: a release tag `vX.Y.Z` must match the
+      # version in pyproject.toml, otherwise we'd build (and try to overwrite) the
+      # wrong version on PyPI. Only enforced for the `release` trigger (which has a tag).
+      - name: Check tag matches package version
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(uv version --short)"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Release tag ($tag) does not match pyproject.toml version ($pkg). Bump the version and re-tag."
+            exit 1
+          fi
+          echo "Tag and package version agree: $pkg"
+
       - name: Build
         run: uv build --out-dir dist
 


### PR DESCRIPTION
## What

A release tag `vX.Y.Z` that disagrees with `pyproject.toml`'s version publishes the wrong version to PyPI, and the mistake only becomes visible once the artifact is public. This adds a guard to the `release` job that compares the two and fails early. It runs only on the `release` trigger, the one that carries a tag.

## Where it came from — and why it matters beyond the check itself

This diff was already written; it had just never been committed. It was sitting as an uncommitted edit **in the deploy box's working tree**, and while it sat there it was silently disabling continuous deployment:

```
##[warning]deploy box has uncommitted changes — skipping to avoid clobbering
```

`deploy/deploy.sh` refuses to touch a dirty checkout — correctly, since the box doubles as a dev machine. But the workflow treats that refusal as a `::warning::` and exits 0, so every push to `main` since 2026-07-31 reported a green deploy while deploying nothing. The box is three commits behind `main` as a result.

Landing the change here preserves it and lets the deploy box go back to a clean tree, which restores CD.

## Verification

`uv version --short` returns the project version (`0.4.0`) on current uv, which is what CI installs (`astral-sh/setup-uv@v6`, `version: latest`). Note it does **not** work on older uv (0.6.x reports uv's own version and rejects `--short`), so this depends on CI staying on latest — which it is pinned to.

https://claude.ai/code/session_01EgezyXcaNNC6vjzNemfNti