### PR TITLE
fix(deploy): measure the change set from the box's HEAD, not github.event.before

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: [self-hosted, deploy]
     steps:
       - name: Fast-forward working tree + restart what changed
-        env:
-          BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
           cd /home/yichuan/visrag
@@ -33,9 +31,19 @@ jobs:
           fi
           if ! git diff --quiet || ! git diff --cached --quiet; then
             echo "::warning::deploy box has uncommitted changes — skipping to avoid clobbering"
+            echo "### Deploy skipped: the box has uncommitted changes" >> "$GITHUB_STEP_SUMMARY"
+            git status --short >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
+          # Measure the change set from where this box actually is, not from
+          # github.event.before. A manual dispatch carries no `before`, and
+          # deploy.sh then falls back to the tip commit alone — so everything
+          # the box was behind by is invisible and the services that changed
+          # are never restarted, while the run still reports success. The
+          # tree's own HEAD is right for both triggers and for a box that has
+          # fallen several commits behind.
+          before=$(git rev-parse HEAD)
           git fetch origin main
           git merge --ff-only origin/main
-          bash deploy/deploy.sh "${BEFORE:-}"
+          bash deploy/deploy.sh "$before"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -25,7 +25,10 @@ say "deploy: ${BEFORE:-<none>} -> ${AFTER}"
 if [ -n "$BEFORE" ] && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
   CHANGED=$(git diff --name-only "$BEFORE" "$AFTER")
 else
-  # First run / unknown base: treat the tip commit's files as the change set.
+  # Defensive fallback only — the workflow passes the box's pre-merge HEAD, so
+  # this should not be reached. It sees just the tip commit, which understates
+  # the change set whenever the box was more than one commit behind.
+  say "WARN: no usable base commit — falling back to the tip commit's files only"
   CHANGED=$(git show --name-only --pretty="" "$AFTER")
 fi
 say "changed: $(echo "$CHANGED" | tr '\n' ' ')"


### PR DESCRIPTION
## The defect

`deploy.yml` passes `github.event.before` to `deploy/deploy.sh`, which uses it to decide what to restart. A manual `workflow_dispatch` carries no `before`, so the script takes its documented fallback: *"treat the tip commit's files as the change set."*

That fallback understates the truth whenever the box is more than one commit behind. Hit for real today: a dispatch fast-forwarded the box across two commits, the newer of which touched only `.github/workflows/release.yml`. The older one changed `web/agent-server.mjs` — which should have restarted the agent — and was never looked at. The box ended up on the right commit running the old code, and the run reported success.

## The fix

Take the box's own HEAD before the fast-forward:

```bash
before=$(git rev-parse HEAD)
git fetch origin main
git merge --ff-only origin/main
bash deploy/deploy.sh "$before"
```

Correct for `push` and `workflow_dispatch` alike, and correct for a box that has fallen any number of commits behind. `deploy.sh` keeps its fallback as defence, but now logs that the change set is understated when it fires.

## Also: make the skip visible

`deploy.sh` refuses to touch a dirty checkout — correct, since the box doubles as a dev machine. But the refusal was a `::warning::` on a run that exits 0, so the Actions list showed a green deploy. That is how CD deployed nothing between 2026-07-31 and 2026-08-28 without anyone noticing. The skip now also writes to `$GITHUB_STEP_SUMMARY`, including the offending `git status --short`, so it appears on the run page rather than only in the log.

https://claude.ai/code/session_01EgezyXcaNNC6vjzNemfNti