### PR TITLE
fix(agent): give the turn cap headroom, and keep partial work when it fires

### DIFF
--- a/web/agent-server.mjs
+++ b/web/agent-server.mjs
@@ -38,6 +38,11 @@ const PORT = parseInt(process.env.AGENT_PORT || "30010", 10)
 const SEARCH_URL = process.env.PIXELRAG_SEARCH_URL || "https://api.pixelrag.ai"
 const MAX_BUDGET = parseFloat(process.env.CHAT_MAX_BUDGET_USD || "2.00")
 const THINKING_TOKENS = parseInt(process.env.CHAT_THINKING_TOKENS || "2000", 10)
+// The system prompt's own worst case — two searches (image-then-text), four
+// tiles, then an answer — lands on eight turns exactly, so a cap of 8 cut off
+// the strategy it asks for. Cost is bounded by CHAT_MAX_BUDGET_USD, which had
+// never once been the binding limit; the turn cap always fired first.
+const MAX_TURNS = parseInt(process.env.CHAT_MAX_TURNS || "12", 10)
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || "*"
 
 // Rate limiting — protects the subscription on a public endpoint.
@@ -307,15 +312,15 @@ const server = http.createServer(async (req, res) => {
     const mcpServer = createSdkMcpServer({ name: "pixelrag", version: "1.0.0", tools })
 
     inFlight++
+    let sentText = false
     try {
-      let sentText = false
       for await (const message of query({
         prompt,
         options: {
           systemPrompt: SYSTEM_PROMPT,
           mcpServers: { pixelrag: mcpServer },
           allowedTools: ["mcp__pixelrag__pixelrag_search", "mcp__pixelrag__pixelrag_tile"],
-          maxTurns: 8,
+          maxTurns: MAX_TURNS,
           maxBudgetUsd: MAX_BUDGET,
           maxThinkingTokens: THINKING_TOKENS,
           includePartialMessages: true,
@@ -349,8 +354,23 @@ const server = http.createServer(async (req, res) => {
         log(`chat done in ${elapsed}s`)
       }
     } catch (err) {
-      log("chat error:", String(err))
-      send("error", { message: String(err) })
+      const detail = String(err)
+      const elapsed = ((Date.now() - t0) / 1000).toFixed(1)
+      // Hitting the turn cap is not a failed turn — the model has usually read
+      // real tiles by then. Discarding that and emitting a raw SDK error string
+      // throws away work the user already waited for.
+      if (/Reached maximum number of turns/i.test(detail)) {
+        if (!sentText) {
+          send("text", {
+            text: "I ran out of steps before I could finish reading the Wikipedia tiles for this one. A narrower or more specific question usually gets there.",
+          })
+        }
+        send("done", { truncated: true })
+        log(`chat TURN-CAPPED in ${elapsed}s (partial answer: ${sentText})`)
+      } else {
+        log("chat error:", detail)
+        send("error", { message: detail })
+      }
     } finally {
       inFlight--
       res.end()

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -352,8 +352,8 @@ export async function POST(req: Request) {
         tools,
       })
 
+      let sentText = false
       try {
-        let sentText = false
         for await (const message of query({
           prompt,
           options: {
@@ -363,7 +363,7 @@ export async function POST(req: Request) {
               "mcp__pixelrag__pixelrag_search",
               "mcp__pixelrag__pixelrag_tile",
             ],
-            maxTurns: 8,
+            maxTurns: parseInt(process.env.CHAT_MAX_TURNS || "12", 10),
             maxBudgetUsd: parseFloat(
               process.env.CHAT_MAX_BUDGET_USD || "0.50"
             ),
@@ -405,7 +405,20 @@ export async function POST(req: Request) {
           send("done", {})
         }
       } catch (err) {
-        send("error", { message: String(err) })
+        const detail = String(err)
+        // Hitting the turn cap is not a failed turn — the model has usually
+        // read real tiles by then, and discarding that to emit a raw SDK error
+        // string throws away work the user already waited for.
+        if (/Reached maximum number of turns/i.test(detail)) {
+          if (!sentText) {
+            send("text", {
+              text: "I ran out of steps before I could finish reading the Wikipedia tiles for this one. A narrower or more specific question usually gets there.",
+            })
+          }
+          send("done", { truncated: true })
+        } else {
+          send("error", { message: detail })
+        }
       } finally {
         controller.close()
       }

--- a/web/app/chat/page.tsx
+++ b/web/app/chat/page.tsx
@@ -60,6 +60,9 @@ interface ChatMessage {
   // grounded in Wikipedia tiles. Marked so the answer cannot be mistaken for
   // an ordinary one.
   degraded?: boolean
+  // The turn cap stopped the agent mid-investigation. Unlike `degraded`, what
+  // it did say is grounded — it is just incomplete.
+  truncated?: boolean
 }
 
 const EXAMPLES = [
@@ -179,7 +182,7 @@ function ChatPageInner() {
         case "search_results": return { ...m, searching: undefined, searches: [...(m.searches || []), { query: data.query as string, hits: data.hits as SearchResult["hits"] }] }
         case "viewing_tile": return { ...m, viewingTile: true, tiles: [...(m.tiles || []), { article_id: data.article_id as number, tile_index: data.tile_index as number, chunk_index: data.chunk_index as number }] }
         case "search_unavailable": return { ...m, searching: undefined, degraded: true }
-        case "done": return { ...m, searching: undefined, viewingTile: false, degraded: m.degraded || Boolean(data.degraded) }
+        case "done": return { ...m, searching: undefined, viewingTile: false, degraded: m.degraded || Boolean(data.degraded), truncated: Boolean(data.truncated) }
         case "error": return { ...m, content: m.content || `Error: ${data.message}`, searching: undefined }
         default: return m
       }
@@ -458,6 +461,15 @@ function AssistantMessage({ message, isStreaming, onTileClick }: { message: Chat
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
           <span className="text-[12px] leading-[1.6] text-[var(--chat-secondary)]">
             Visual search was unavailable, so this reply was not read off Wikipedia screenshots. Try again in a moment.
+          </span>
+        </div>
+      )}
+
+      {message.truncated && !message.degraded && (
+        <div className="mb-4 flex items-start gap-2.5 rounded-lg border border-[var(--chat-border)] bg-[var(--chat-card)] px-3.5 py-2.5">
+          <Clock className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--chat-muted)]" />
+          <span className="text-[12px] leading-[1.6] text-[var(--chat-secondary)]">
+            Stopped early — this answer is based on the tiles read so far, not a finished search.
           </span>
         </div>
       )}


### PR DESCRIPTION
## Why 8 was the wrong number

The system prompt asks for this on an image question:

> do image-only search FIRST … Then do follow-up text searches to verify or compare candidates
> … View at least 2-3 tiles … view at most 4 tiles total

Two searches + four tiles + the answer is **eight turns**. `maxTurns: 8` therefore cut off the strategy the prompt itself describes, on exactly its slowest legitimate path.

## What the production log says

3775 sessions:

| outcome | count | share |
|---|---:|---:|
| succeeded | 3389 | 89.8% |
| **turn-cap failure** | **198** | **5.2%** |
| other failure | 188 | 5.0% |

Successful sessions, by duration (the log has no per-turn counter, so duration is the proxy):

| | |
|---|---:|
| median | 30.6s |
| p90 | 51.5s |
| p95 | 65.0s |
| under 60s | 93.4% |

Two conclusions, which are the two checks `direction.md` asked for before touching this constant:

1. **The cap is not systemically tight.** The bulk of successful work finishes nowhere near it, so raising it does not make typical sessions slower or more expensive — it only affects the tail that currently fails outright.
2. **The cost guardrail has never been the binding limit.** Zero sessions failed on budget. `CHAT_MAX_BUDGET_USD` (2.00 in production) never got a chance to bind, because the turn cap always fired first. Raising the turn cap moves the binding constraint to the one that should be binding — cost — instead of an arbitrary step count.

## Changes

- `maxTurns` 8 → 12, configurable via `CHAT_MAX_TURNS`, in both chat backends.
- **Hitting the cap no longer discards the turn.** It used to throw away everything produced and surface the raw SDK string `Reached maximum number of turns` as the user's answer, even though the model had usually read real tiles by then. The partial answer is now kept, the turn ends `done {truncated:true}` instead of `error`, and it logs `chat TURN-CAPPED`. When nothing was produced at all, the user gets a sentence in plain language instead of an internal error.
- The UI marks a truncated answer, distinctly from the `degraded` marker added in #147 — degraded means *ungrounded*, truncated means *grounded but incomplete*.

## Verification

`npm test` (10 pass), `npm run typecheck` clean, `npm run build` passes, eslint reports no new problems.

https://claude.ai/code/session_01EgezyXcaNNC6vjzNemfNti