### PR TITLE
fix(serve): bound query image decode and batch size to prevent OOM/DoS

### DIFF
--- a/serve/src/pixelrag_serve/api.py
+++ b/serve/src/pixelrag_serve/api.py
@@ -171,7 +171,9 @@ class Query(BaseModel):
 
 
 class SearchRequest(BaseModel):
-    queries: list[Query]
+    # Bounded: an unbounded batch multiplies every per-query cost (embedding,
+    # image decode) on the public endpoint. Real callers send 1; 32 is generous.
+    queries: list[Query] = Field(max_length=32)
     # Bounded: fetch_k = n_docs * 10 feeds FAISS search k, so an unbounded value
     # is a trivial OOM/DoS on the public endpoint. Largest real caller uses 10.
     n_docs: int = Field(default=10, ge=1, le=1000)
@@ -271,6 +273,12 @@ class StatusResponse(BaseModel):
 
 DEFAULT_INSTRUCTION = "Retrieve images or text relevant to the user's query."
 
+# Bounds for attacker-controlled query images on the public /search endpoint.
+# ~10 MB of base64 caps the payload/decode; 25 MP caps the decoded RGB canvas
+# (query images are downscaled far below this for the VL model anyway).
+_MAX_IMAGE_B64_LEN = 10 * 1024 * 1024
+_MAX_IMAGE_PIXELS = 25_000_000
+
 
 def _parse_queries(
     queries: list[Query], instruction: str | None = None
@@ -291,8 +299,27 @@ def _parse_queries(
             img_data = q.image
             if img_data.startswith("data:"):
                 img_data = img_data.split(",", 1)[-1]
-            img_bytes = base64.b64decode(img_data)
-            img = Image.open(io.BytesIO(img_bytes)).convert("RGB")
+            # Public endpoint: q.image is attacker-controlled. Bound the payload
+            # and the decoded canvas so an oversized blob or a tiny
+            # "decompression bomb" can't OOM the service, and turn any decode
+            # failure into a clean 400 instead of an uncaught 500.
+            if len(img_data) > _MAX_IMAGE_B64_LEN:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"image too large (max {_MAX_IMAGE_B64_LEN} base64 chars)",
+                )
+            try:
+                img = Image.open(io.BytesIO(base64.b64decode(img_data)))
+                if img.width * img.height > _MAX_IMAGE_PIXELS:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"image too large (max {_MAX_IMAGE_PIXELS} pixels)",
+                    )
+                img = img.convert("RGB")
+            except HTTPException:
+                raise
+            except Exception:
+                raise HTTPException(status_code=400, detail="invalid image data")
             user_content.append({"type": "image", "image": img})
         if q.text:
             user_content.append({"type": "text", "text": q.text})

--- a/tests/test_serve_image_input.py
+++ b/tests/test_serve_image_input.py
@@ -1,0 +1,57 @@
+"""Input bounds on the public /search endpoint (OOM/DoS hardening).
+
+`_parse_queries` decodes attacker-controlled base64 images and `SearchRequest`
+caps the batch size. A crafted request must not exhaust memory or turn an
+uncaught decode error into a 500 — the same public-endpoint hardening as the
+n_docs bound.
+"""
+
+import base64
+import io
+
+import pytest
+from fastapi import HTTPException
+from PIL import Image
+from pydantic import ValidationError
+
+from pixelrag_serve.api import Query, SearchRequest, _parse_queries
+
+
+def _png_b64(w: int, h: int) -> str:
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h)).save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def test_queries_batch_is_capped():
+    SearchRequest(queries=[Query(text="ok")])  # small batch fine
+    with pytest.raises(ValidationError):
+        SearchRequest(queries=[Query(text="x")] * 33)
+
+
+def test_valid_image_decodes():
+    _, images = _parse_queries([Query(image=_png_b64(4, 4))])
+    assert images[0] is not None and images[0].mode == "RGB"
+
+
+def test_corrupt_image_is_400_not_500():
+    not_an_image = base64.b64encode(b"hello world, definitely not a png").decode()
+    with pytest.raises(HTTPException) as e:
+        _parse_queries([Query(image=not_an_image)])
+    assert e.value.status_code == 400
+
+
+def test_oversized_payload_is_400(monkeypatch):
+    monkeypatch.setattr("pixelrag_serve.api._MAX_IMAGE_B64_LEN", 16)
+    with pytest.raises(HTTPException) as e:
+        _parse_queries([Query(image=_png_b64(4, 4))])  # base64 longer than 16
+    assert e.value.status_code == 400
+
+
+def test_decompression_bomb_is_400(monkeypatch):
+    # A small image over a lowered pixel cap stands in for a bomb whose header
+    # claims a huge canvas — the guard must reject before .convert() allocates.
+    monkeypatch.setattr("pixelrag_serve.api._MAX_IMAGE_PIXELS", 100)
+    with pytest.raises(HTTPException) as e:
+        _parse_queries([Query(image=_png_b64(50, 50))])  # 2500 px > 100
+    assert e.value.status_code == 400


### PR DESCRIPTION
## Problem

The public `/search` endpoint accepts attacker-controlled query images and an
unbounded batch, with no guards on either. In `_parse_queries`
(`serve/src/pixelrag_serve/api.py`), each query's base64 `image` goes straight
into:

```python
img_bytes = base64.b64decode(img_data)
img = Image.open(io.BytesIO(img_bytes)).convert("RGB")
```

Three ways this is a trivial OOM/DoS on the public endpoint — the same class as
the `n_docs` bound in #122:

1. **Decompression bomb.** A tiny base64 payload can decode to an enormous
   canvas; `.convert("RGB")` then forces a huge allocation. Pillow's default
   only *warns* up to ~179M px before throwing an **uncaught**
   `DecompressionBombError` → HTTP 500.
2. **Unbounded payload.** No cap on the base64 string length or decoded bytes.
3. **Unbounded batch.** `queries: list[Query]` has no `max_length`, so a single
   request can carry thousands of queries, multiplying (1) and (2).

Corrupt/invalid base64 also raises uncaught → 500 instead of a clean 400.

## Fix

Declarative bounds plus a guarded decode, no behavior change for valid requests:

- `queries: list[Query] = Field(max_length=32)` — real callers send 1; 32 is
  generous.
- Cap the base64 payload (10 MB) before decoding.
- Read the image dimensions from the header and reject over a pixel cap
  (25 MP) **before** `.convert()` allocates — query images are downscaled far
  below this for the VL model anyway.
- Wrap the decode so any failure (bad base64, corrupt image, bomb) returns a
  clean `400` instead of an uncaught `500`.

Out-of-range batches now return `422`; oversized/invalid images return `400`.

## Tests

Added `tests/test_serve_image_input.py` (plain `pytest`, no model/FAISS load —
targets the validation layer directly):

- batch over the cap raises `ValidationError` (→ 422); a normal batch passes.
- a valid image decodes to RGB.
- corrupt image data → 400, not 500.
- oversized base64 payload → 400 (cap monkeypatched small).
- an image over the pixel cap → 400 before decode (stands in for a bomb).

All pass; `ruff check` and `ruff format --check` are clean.
